### PR TITLE
Add CI: format, lint, tests and MSRV enforcement

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -17,7 +17,7 @@ jobs:
     name: cargo-deny
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: EmbarkStudios/cargo-deny-action@v2
         with:
           command: check advisories licenses bans sources

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,0 +1,23 @@
+name: Audit
+
+# Dependency problems appear when an advisory is published, not when we happen
+# to push, so this runs on a schedule as well as on changes to the manifest.
+on:
+  push:
+    branches: [main]
+    paths: [Cargo.toml, Cargo.lock, deny.toml, .github/workflows/audit.yml]
+  pull_request:
+    paths: [Cargo.toml, Cargo.lock, deny.toml, .github/workflows/audit.yml]
+  schedule:
+    - cron: "0 6 * * 1"
+  workflow_dispatch:
+
+jobs:
+  deny:
+    name: cargo-deny
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: EmbarkStudios/cargo-deny-action@v2
+        with:
+          command: check advisories licenses bans sources

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     name: Format
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt
@@ -25,7 +25,7 @@ jobs:
     name: Clippy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
@@ -40,7 +40,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - run: cargo test --all-features
@@ -52,7 +52,7 @@ jobs:
     name: Minimum supported Rust version
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - id: msrv
         run: echo "version=$(cargo metadata --format-version 1 --no-deps | jq -r '.packages[0].rust_version')" >> "$GITHUB_OUTPUT"
       - uses: dtolnay/rust-toolchain@master

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,62 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+env:
+  CARGO_TERM_COLOR: always
+  # Fail fast on a warning rather than letting one accumulate quietly.
+  RUSTFLAGS: -D warnings
+
+jobs:
+  fmt:
+    name: Format
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+      - run: cargo fmt --all --check
+
+  clippy:
+    name: Clippy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo clippy --all-targets --all-features -- -D warnings
+
+  test:
+    name: Test (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo test --all-features
+
+  # Pinned to the `rust-version` in Cargo.toml. This job is what tells us a
+  # dependency bump has raised our floor, instead of a user on an older
+  # toolchain finding out for us.
+  msrv:
+    name: Minimum supported Rust version
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - id: msrv
+        run: echo "version=$(cargo metadata --format-version 1 --no-deps | jq -r '.packages[0].rust_version')" >> "$GITHUB_OUTPUT"
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ steps.msrv.outputs.version }}
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo check --all-targets --all-features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16,9 +16,9 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "atomic-waker"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,9 @@
 name = "pokeductor"
 version = "0.2.0"
 edition = "2021"
+# Set by our dependency floor rather than by anything we use directly:
+# `image` and `darling` both require 1.88. Enforced by the `msrv` CI job.
+rust-version = "1.88"
 description = "A terminal Pokedex and evolution analyzer with sprite rendering, offline type and party analysis, and an on-disk cache for offline use"
 license = "MIT"
 readme = "README.md"

--- a/README.md
+++ b/README.md
@@ -7,7 +7,9 @@ chains as connected sprite cards, and analyse type coverage for a single species
 or a whole party — rendered with Unicode half-blocks in a PICO-8-inspired
 palette. Built in Rust with [ratatui](https://ratatui.rs/).
 
+[![CI](https://github.com/Huseynteymurzade28/pokeductor/actions/workflows/ci.yml/badge.svg)](https://github.com/Huseynteymurzade28/pokeductor/actions/workflows/ci.yml)
 ![Rust](https://img.shields.io/badge/Rust-2021-orange?logo=rust)
+![MSRV](https://img.shields.io/badge/MSRV-1.88-orange?logo=rust)
 ![ratatui](https://img.shields.io/badge/TUI-ratatui%200.29-blueviolet)
 ![Async](https://img.shields.io/badge/runtime-tokio-green)
 ![License](https://img.shields.io/badge/license-MIT-yellow)
@@ -35,7 +37,7 @@ cargo run --release
 
 ### Requirements
 
-- **Rust** (stable, 2021 edition) — via [rustup](https://rustup.rs/).
+- **Rust 1.88 or newer** (2021 edition) — via [rustup](https://rustup.rs/).
 - A **truecolor (24-bit) terminal**. Sprites are drawn as RGB half-blocks and
   will look wrong on a 256-colour terminal.
 - A font with **Unicode block and box-drawing glyphs** — any Nerd Font, Fira
@@ -341,6 +343,26 @@ shown.
 [`thiserror`](https://crates.io/crates/thiserror)
 
 ---
+
+## Development
+
+The checks CI enforces on every pull request, in the order it runs them:
+
+```bash
+cargo fmt --all --check
+cargo clippy --all-targets --all-features -- -D warnings
+cargo test --all-features
+```
+
+Tests run on Linux, macOS and Windows. A separate job builds against the
+`rust-version` floor declared in `Cargo.toml`, so a dependency bump that raises
+the minimum supported Rust version fails the build rather than reaching users.
+`cargo deny` checks licenses and RUSTSEC advisories weekly and whenever the
+manifest changes.
+
+Everything under `typechart.rs`, `team.rs`, `query.rs` and `models.rs` is pure
+and unit-tested; new logic belongs there rather than in `app.rs` or `ui.rs`
+wherever it can be expressed without a terminal or a network.
 
 ## Credits
 

--- a/deny.toml
+++ b/deny.toml
@@ -3,6 +3,14 @@
 [advisories]
 # Fail on any unfixed RUSTSEC advisory in the dependency tree.
 yanked = "deny"
+ignore = [
+    # RUSTSEC-2024-0436: `paste` is unmaintained — its author archived the
+    # repository. It is not a vulnerability, and there is nothing to act on
+    # here: it reaches us only through `ratatui`, no upgrade exists, and it is
+    # a proc-macro crate, so it runs at compile time and contributes no code to
+    # the shipped binary. Drop this entry once ratatui stops depending on it.
+    "RUSTSEC-2024-0436",
+]
 
 [licenses]
 # We ship a binary users install with `cargo install`, so every dependency

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,34 @@
+# Configuration for `cargo deny`, run by .github/workflows/audit.yml.
+
+[advisories]
+# Fail on any unfixed RUSTSEC advisory in the dependency tree.
+yanked = "deny"
+
+[licenses]
+# We ship a binary users install with `cargo install`, so every dependency
+# needs a license that permits redistribution.
+allow = [
+    "0BSD",
+    "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "BSL-1.0",
+    "CC0-1.0",
+    "ISC",
+    "MIT",
+    "MIT-0",
+    "MPL-2.0",
+    "Unicode-3.0",
+    "Unlicense",
+    "Zlib",
+]
+confidence-threshold = 0.8
+
+[bans]
+multiple-versions = "warn"
+wildcards = "deny"
+
+[sources]
+unknown-registry = "deny"
+unknown-git = "deny"

--- a/src/api.rs
+++ b/src/api.rs
@@ -35,15 +35,22 @@ pub fn build_client() -> Result<reqwest::Client, ApiError> {
 }
 
 /// Fetches the master list of Pokemon names for the sidebar.
-pub async fn fetch_pokemon_list(
-    client: &reqwest::Client,
-) -> Result<Vec<PokemonEntry>, ApiError> {
+pub async fn fetch_pokemon_list(client: &reqwest::Client) -> Result<Vec<PokemonEntry>, ApiError> {
     let url = format!("{BASE_URL}/pokemon?limit={LIST_LIMIT}&offset=0");
-    let raw: NamedList = client.get(url).send().await?.error_for_status()?.json().await?;
+    let raw: NamedList = client
+        .get(url)
+        .send()
+        .await?
+        .error_for_status()?
+        .json()
+        .await?;
     let entries = raw
         .results
         .into_iter()
-        .map(|r| PokemonEntry { id: id_from_url(&r.url), name: r.name })
+        .map(|r| PokemonEntry {
+            id: id_from_url(&r.url),
+            name: r.name,
+        })
         .collect();
     Ok(entries)
 }
@@ -58,7 +65,13 @@ pub async fn fetch_type_members(
     type_name: &str,
 ) -> Result<Vec<String>, ApiError> {
     let url = format!("{BASE_URL}/type/{type_name}");
-    let raw: RawType = client.get(url).send().await?.error_for_status()?.json().await?;
+    let raw: RawType = client
+        .get(url)
+        .send()
+        .await?
+        .error_for_status()?
+        .json()
+        .await?;
     Ok(raw.pokemon.into_iter().map(|p| p.pokemon.name).collect())
 }
 
@@ -135,17 +148,22 @@ pub async fn translate_text(
 /// The description comes from the game flavor text rather than the effect
 /// entries: PokeAPI carries flavor in all five languages the info card uses,
 /// while effect text exists only in English, German and French.
-pub async fn fetch_ability(
-    client: &reqwest::Client,
-    name: &str,
-) -> Result<AbilityInfo, ApiError> {
+pub async fn fetch_ability(client: &reqwest::Client, name: &str) -> Result<AbilityInfo, ApiError> {
     let url = format!("{BASE_URL}/ability/{name}");
-    let raw: RawAbility = client.get(url).send().await?.error_for_status()?.json().await?;
+    let raw: RawAbility = client
+        .get(url)
+        .send()
+        .await?
+        .error_for_status()?
+        .json()
+        .await?;
 
     let mut names = HashMap::new();
     for n in &raw.names {
         if CARD_LANGS.contains(&n.language.name.as_str()) {
-            names.entry(n.language.name.clone()).or_insert_with(|| n.name.clone());
+            names
+                .entry(n.language.name.clone())
+                .or_insert_with(|| n.name.clone());
         }
     }
 
@@ -160,7 +178,11 @@ pub async fn fetch_ability(
         }
     }
 
-    Ok(AbilityInfo { name: raw.name, names, flavors })
+    Ok(AbilityInfo {
+        name: raw.name,
+        names,
+        flavors,
+    })
 }
 
 /// Fetches and decodes just the sprite for a named species. Used to lazily
@@ -178,16 +200,32 @@ pub async fn fetch_named_sprite(
 
 /// Downloads a sprite PNG and decodes it into raw RGBA pixels.
 pub async fn fetch_sprite(client: &reqwest::Client, url: &str) -> Result<Sprite, ApiError> {
-    let bytes = client.get(url).send().await?.error_for_status()?.bytes().await?;
+    let bytes = client
+        .get(url)
+        .send()
+        .await?
+        .error_for_status()?
+        .bytes()
+        .await?;
     let image = image::load_from_memory(&bytes)?.to_rgba8();
     let (width, height) = image.dimensions();
     let pixels = image.pixels().map(|p| p.0).collect();
-    Ok(Sprite { width, height, pixels })
+    Ok(Sprite {
+        width,
+        height,
+        pixels,
+    })
 }
 
 async fn fetch_detail(client: &reqwest::Client, name: &str) -> Result<PokemonDetail, ApiError> {
     let url = format!("{BASE_URL}/pokemon/{name}");
-    let raw: RawPokemon = client.get(url).send().await?.error_for_status()?.json().await?;
+    let raw: RawPokemon = client
+        .get(url)
+        .send()
+        .await?
+        .error_for_status()?
+        .json()
+        .await?;
 
     let mut types: Vec<(u8, String)> = raw
         .types
@@ -199,7 +237,15 @@ async fn fetch_detail(client: &reqwest::Client, name: &str) -> Result<PokemonDet
     let mut abilities: Vec<(u8, Ability)> = raw
         .abilities
         .into_iter()
-        .map(|a| (a.slot, Ability { name: a.ability.name, is_hidden: a.is_hidden }))
+        .map(|a| {
+            (
+                a.slot,
+                Ability {
+                    name: a.ability.name,
+                    is_hidden: a.is_hidden,
+                },
+            )
+        })
         .collect();
     abilities.sort_by_key(|(slot, _)| *slot);
 
@@ -255,7 +301,13 @@ struct SpeciesInfo {
 /// and flavor text in every language we care about for the info card.
 async fn fetch_species(client: &reqwest::Client, name: &str) -> Result<SpeciesInfo, ApiError> {
     let url = format!("{BASE_URL}/pokemon-species/{name}");
-    let species: RawSpecies = client.get(url).send().await?.error_for_status()?.json().await?;
+    let species: RawSpecies = client
+        .get(url)
+        .send()
+        .await?
+        .error_for_status()?
+        .json()
+        .await?;
 
     let chain_url = species
         .evolution_chain
@@ -265,7 +317,9 @@ async fn fetch_species(client: &reqwest::Client, name: &str) -> Result<SpeciesIn
     let mut genera = HashMap::new();
     for g in &species.genera {
         if CARD_LANGS.contains(&g.language.name.as_str()) {
-            genera.entry(g.language.name.clone()).or_insert_with(|| g.genus.clone());
+            genera
+                .entry(g.language.name.clone())
+                .or_insert_with(|| g.genus.clone());
         }
     }
 
@@ -293,7 +347,13 @@ async fn fetch_species(client: &reqwest::Client, name: &str) -> Result<SpeciesIn
 
 /// Fetches and parses an evolution chain from its API URL.
 async fn fetch_chain(client: &reqwest::Client, url: &str) -> Result<EvolutionTree, ApiError> {
-    let chain: RawEvolutionChain = client.get(url).send().await?.error_for_status()?.json().await?;
+    let chain: RawEvolutionChain = client
+        .get(url)
+        .send()
+        .await?
+        .error_for_status()?
+        .json()
+        .await?;
     Ok(parse_chain(&chain.chain))
 }
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -301,7 +301,9 @@ impl App {
             let client = self.client.clone();
             tokio::spawn(async move {
                 let members = resolve_type_members(&client, &type_name).await;
-                let _ = tx.send(Message::TypeMembersLoaded { type_name, members }).await;
+                let _ = tx
+                    .send(Message::TypeMembersLoaded { type_name, members })
+                    .await;
             });
         }
     }
@@ -365,14 +367,18 @@ impl App {
             // Translations cost a rate-limited third-party request, so a cached
             // one is worth reaching for before we ask again.
             if let Some(text) = cache::load_translation(&name, &lang).await {
-                let _ = tx.send(Message::FlavorTranslated { name, lang, text }).await;
+                let _ = tx
+                    .send(Message::FlavorTranslated { name, lang, text })
+                    .await;
                 return;
             }
             // On failure we simply never send: the UI keeps the English text and
             // the in-flight flag stops us from hammering a rate-limited service.
             if let Ok(text) = api::translate_text(&client, &source, "en", &lang).await {
                 cache::store_translation(&name, &lang, &text).await;
-                let _ = tx.send(Message::FlavorTranslated { name, lang, text }).await;
+                let _ = tx
+                    .send(Message::FlavorTranslated { name, lang, text })
+                    .await;
             }
         });
     }
@@ -447,7 +453,11 @@ impl App {
                     self.request_selected();
                 }
             }
-            Message::PokemonLoaded { detail, evolution, sprite } => {
+            Message::PokemonLoaded {
+                detail,
+                evolution,
+                sprite,
+            } => {
                 let name = detail.name.clone();
                 if self.loading_detail.as_deref() == Some(name.as_str()) {
                     self.loading_detail = None;
@@ -479,7 +489,8 @@ impl App {
                 self.type_loading.remove(&type_name);
                 // Recorded even when empty — a mistyped type must settle on
                 // "no results" instead of being requested again every frame.
-                self.type_members.insert(type_name, members.into_iter().collect());
+                self.type_members
+                    .insert(type_name, members.into_iter().collect());
                 self.recompute_filter();
             }
             Message::FlavorTranslated { name, lang, text } => {
@@ -898,7 +909,11 @@ async fn resolve_bundle(client: &reqwest::Client, name: &str) -> Message {
         Ok((detail, evolution, sprite)) => {
             cache::store_bundle(name, &detail, &evolution).await;
             record_sprite(name, sprite.as_ref()).await;
-            Message::PokemonLoaded { detail, evolution, sprite }
+            Message::PokemonLoaded {
+                detail,
+                evolution,
+                sprite,
+            }
         }
         Err(err) => Message::Error(err.to_string()),
     }
@@ -906,11 +921,7 @@ async fn resolve_bundle(client: &reqwest::Client, name: &str) -> Message {
 
 /// Cache-first sprite lookup for a species whose artwork URL we already know
 /// (because its details came out of the cache alongside it).
-async fn resolve_sprite(
-    client: &reqwest::Client,
-    name: &str,
-    url: Option<&str>,
-) -> Option<Sprite> {
+async fn resolve_sprite(client: &reqwest::Client, name: &str, url: Option<&str>) -> Option<Sprite> {
     if let Some(sprite) = cache::load_sprite(name).await {
         return Some(sprite);
     }

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -61,7 +61,10 @@ struct Envelope<T> {
 pub async fn load_list() -> Option<CachedList> {
     let path = root()?.join("list.json");
     let entries = read_json(&path).await?;
-    Some(CachedList { entries, fresh: age(&path).await.is_some_and(|a| a < LIST_TTL) })
+    Some(CachedList {
+        entries,
+        fresh: age(&path).await.is_some_and(|a| a < LIST_TTL),
+    })
 }
 
 pub async fn store_list(entries: &[PokemonEntry]) {
@@ -84,7 +87,10 @@ pub async fn store_bundle(name: &str, detail: &PokemonDetail, evolution: &Evolut
     // Cloning to build the owned envelope costs one copy of a small record on
     // a background task, which is cheaper than threading lifetimes through
     // serde for a write that happens once per species per month.
-    let bundle = CachedBundle { detail: detail.clone(), evolution: evolution.clone() };
+    let bundle = CachedBundle {
+        detail: detail.clone(),
+        evolution: evolution.clone(),
+    };
     write_json(&path, &bundle).await;
 }
 
@@ -126,7 +132,11 @@ pub async fn load_sprite(name: &str) -> Option<Sprite> {
     let bytes = tokio::fs::read(&path).await.ok()?;
     let image = image::load_from_memory(&bytes).ok()?.to_rgba8();
     let (width, height) = image.dimensions();
-    Some(Sprite { width, height, pixels: image.pixels().map(|p| p.0).collect() })
+    Some(Sprite {
+        width,
+        height,
+        pixels: image.pixels().map(|p| p.0).collect(),
+    })
 }
 
 pub async fn store_sprite(name: &str, sprite: &Sprite) {
@@ -193,11 +203,19 @@ fn root() -> Option<&'static Path> {
 }
 
 fn ability_path(name: &str) -> Option<PathBuf> {
-    Some(root()?.join("abilities").join(format!("{}.json", slug(name))))
+    Some(
+        root()?
+            .join("abilities")
+            .join(format!("{}.json", slug(name))),
+    )
 }
 
 fn type_path(type_name: &str) -> Option<PathBuf> {
-    Some(root()?.join("types").join(format!("{}.json", slug(type_name))))
+    Some(
+        root()?
+            .join("types")
+            .join(format!("{}.json", slug(type_name))),
+    )
 }
 
 fn sprite_path(name: &str) -> Option<PathBuf> {
@@ -205,7 +223,11 @@ fn sprite_path(name: &str) -> Option<PathBuf> {
 }
 
 fn translation_path(name: &str, lang: &str) -> Option<PathBuf> {
-    Some(root()?.join("translations").join(format!("{}.{}.txt", slug(name), slug(lang))))
+    Some(
+        root()?
+            .join("translations")
+            .join(format!("{}.{}.txt", slug(name), slug(lang))),
+    )
 }
 
 /// Reduces an API name to something safe to use as a single filename.
@@ -215,7 +237,13 @@ fn translation_path(name: &str, lang: &str) -> Option<PathBuf> {
 /// directory or collide with a path separator.
 fn slug(name: &str) -> String {
     name.chars()
-        .map(|c| if c.is_ascii_alphanumeric() || c == '-' { c.to_ascii_lowercase() } else { '_' })
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '-' {
+                c.to_ascii_lowercase()
+            } else {
+                '_'
+            }
+        })
         .collect()
 }
 
@@ -228,7 +256,10 @@ async fn read_json<T: DeserializeOwned>(path: &Path) -> Option<T> {
 }
 
 async fn write_json<T: Serialize>(path: &Path, data: &T) {
-    let envelope = Envelope { version: VERSION, data };
+    let envelope = Envelope {
+        version: VERSION,
+        data,
+    };
     if let Ok(bytes) = serde_json::to_vec(&envelope) {
         write_atomic(path, &bytes).await;
     }
@@ -305,6 +336,9 @@ mod tests {
         let bytes = encode_png(&sprite).unwrap();
         let decoded = image::load_from_memory(&bytes).unwrap().to_rgba8();
         assert_eq!(decoded.dimensions(), (2, 1));
-        assert_eq!(decoded.pixels().map(|p| p.0).collect::<Vec<_>>(), sprite.pixels);
+        assert_eq!(
+            decoded.pixels().map(|p| p.0).collect::<Vec<_>>(),
+            sprite.pixels
+        );
     }
 }

--- a/src/models.rs
+++ b/src/models.rs
@@ -294,7 +294,12 @@ impl EvolutionTree {
     /// Length of the longest evolution path (number of stages), e.g. 3 for
     /// Bulbasaur → Ivysaur → Venusaur.
     pub fn depth(&self) -> usize {
-        1 + self.children.iter().map(EvolutionTree::depth).max().unwrap_or(0)
+        1 + self
+            .children
+            .iter()
+            .map(EvolutionTree::depth)
+            .max()
+            .unwrap_or(0)
     }
 }
 
@@ -359,7 +364,12 @@ impl Sprite {
         if found {
             (x0, y0, x1, y1)
         } else {
-            (0, 0, self.width.saturating_sub(1), self.height.saturating_sub(1))
+            (
+                0,
+                0,
+                self.width.saturating_sub(1),
+                self.height.saturating_sub(1),
+            )
         }
     }
 }
@@ -384,22 +394,34 @@ mod tests {
     use super::*;
 
     fn entry(id: u32) -> PokemonEntry {
-        PokemonEntry { name: String::new(), id }
+        PokemonEntry {
+            name: String::new(),
+            id,
+        }
     }
 
     #[test]
     fn generation_boundaries_land_on_the_right_side() {
         // First and last species of every generation.
         for (id, gen) in [
-            (1, 1), (151, 1),
-            (152, 2), (251, 2),
-            (252, 3), (386, 3),
-            (387, 4), (493, 4),
-            (494, 5), (649, 5),
-            (650, 6), (721, 6),
-            (722, 7), (809, 7),
-            (810, 8), (905, 8),
-            (906, 9), (1025, 9),
+            (1, 1),
+            (151, 1),
+            (152, 2),
+            (251, 2),
+            (252, 3),
+            (386, 3),
+            (387, 4),
+            (493, 4),
+            (494, 5),
+            (649, 5),
+            (650, 6),
+            (721, 6),
+            (722, 7),
+            (809, 7),
+            (810, 8),
+            (905, 8),
+            (906, 9),
+            (1025, 9),
         ] {
             assert_eq!(entry(id).generation(), Some(gen), "dex #{id}");
         }

--- a/src/team.rs
+++ b/src/team.rs
@@ -164,7 +164,12 @@ pub fn analyse(team: &[&PokemonDetail]) -> TeamAnalysis {
         })
         .collect();
 
-    TeamAnalysis { shared_weaknesses, unresisted, offense_gaps, ability_immunities }
+    TeamAnalysis {
+        shared_weaknesses,
+        unresisted,
+        offense_gaps,
+        ability_immunities,
+    }
 }
 
 #[cfg(test)]
@@ -188,7 +193,10 @@ mod tests {
             types: types.iter().map(|t| t.to_string()).collect(),
             abilities: abilities
                 .iter()
-                .map(|a| Ability { name: a.to_string(), is_hidden: false })
+                .map(|a| Ability {
+                    name: a.to_string(),
+                    is_hidden: false,
+                })
                 .collect(),
             stats: Vec::new(),
             height: 0,
@@ -271,7 +279,10 @@ mod tests {
 
         // Fire hits Grass/Ice/Bug/Steel; Flying hits Grass/Fighting/Bug.
         for covered in ["grass", "ice", "bug", "steel", "fighting"] {
-            assert!(!analysis.offense_gaps.contains(&covered), "{covered} is covered");
+            assert!(
+                !analysis.offense_gaps.contains(&covered),
+                "{covered} is covered"
+            );
         }
         // Nothing it carries is strong against Water or Dragon.
         assert!(analysis.offense_gaps.contains(&"water"));

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -10,8 +10,8 @@ use ratatui::Frame;
 use crate::app::{App, Focus, SortKey};
 use crate::i18n::{EvoStrings, Language, Strings};
 use crate::models::{title_case, EvolutionTree, Sprite};
-use crate::theme;
 use crate::team;
+use crate::theme;
 use crate::typechart;
 
 const SPINNER: [&str; 10] = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
@@ -24,7 +24,10 @@ pub fn render(frame: &mut Frame, app: &mut App) {
     let strings = app.language.strings();
 
     // Paint the whole background first so gaps share the pastel base color.
-    frame.render_widget(Block::default().style(Style::default().bg(theme::BASE)), area);
+    frame.render_widget(
+        Block::default().style(Style::default().bg(theme::BASE)),
+        area,
+    );
 
     let rows = Layout::vertical([
         Constraint::Length(1), // header
@@ -36,13 +39,13 @@ pub fn render(frame: &mut Frame, app: &mut App) {
     render_header(frame, app, &strings, rows[0]);
     render_footer(frame, &strings, rows[2]);
 
-    let cols = Layout::horizontal([Constraint::Percentage(32), Constraint::Percentage(68)])
-        .split(rows[1]);
+    let cols =
+        Layout::horizontal([Constraint::Percentage(32), Constraint::Percentage(68)]).split(rows[1]);
 
     render_sidebar(frame, app, &strings, cols[0]);
 
-    let right = Layout::vertical([Constraint::Percentage(58), Constraint::Percentage(42)])
-        .split(cols[1]);
+    let right =
+        Layout::vertical([Constraint::Percentage(58), Constraint::Percentage(42)]).split(cols[1]);
     render_details(frame, app, &strings, right[0]);
     render_evolution(frame, app, &strings, right[1]);
 
@@ -108,7 +111,10 @@ fn render_sidebar(frame: &mut Frame, app: &mut App, s: &Strings, area: Rect) {
     let search_block = panel_block(s.search_title, search_focused);
     let cursor = if search_focused { "▏" } else { "" };
     let query_line = if app.query.is_empty() && !search_focused {
-        Line::from(Span::styled(s.search_hint, Style::default().fg(theme::OVERLAY)))
+        Line::from(Span::styled(
+            s.search_hint,
+            Style::default().fg(theme::OVERLAY),
+        ))
     } else {
         Line::from(vec![
             Span::styled("🔍 ", Style::default().fg(theme::SAPPHIRE)),
@@ -124,7 +130,12 @@ fn render_sidebar(frame: &mut Frame, app: &mut App, s: &Strings, area: Rect) {
         SortKey::Dex => s.sort_dex,
         SortKey::Name => s.sort_name,
     };
-    let title = format!("{}({}) ⇅ {} ", s.sidebar_title, app.filtered.len(), sort_badge);
+    let title = format!(
+        "{}({}) ⇅ {} ",
+        s.sidebar_title,
+        app.filtered.len(),
+        sort_badge
+    );
     let list_block = panel_block_owned(title, list_focused);
     let inner = list_block.inner(rows[1]);
     frame.render_widget(&list_block, rows[1]);
@@ -167,14 +178,12 @@ fn render_sidebar(frame: &mut Frame, app: &mut App, s: &Strings, area: Rect) {
         })
         .collect();
 
-    let list = List::new(items)
-        .highlight_symbol("▶ ")
-        .highlight_style(
-            Style::default()
-                .fg(theme::BASE)
-                .bg(theme::MAUVE)
-                .add_modifier(Modifier::BOLD),
-        );
+    let list = List::new(items).highlight_symbol("▶ ").highlight_style(
+        Style::default()
+            .fg(theme::BASE)
+            .bg(theme::MAUVE)
+            .add_modifier(Modifier::BOLD),
+    );
     frame.render_stateful_widget(list, inner, &mut app.list_state);
 }
 
@@ -235,7 +244,9 @@ fn render_details(frame: &mut Frame, app: &App, s: &Strings, area: Rect) {
     if let Some(genus) = detail.genus_for(lang_code) {
         lines.push(Line::from(Span::styled(
             genus.to_string(),
-            Style::default().fg(theme::PEACH).add_modifier(Modifier::ITALIC),
+            Style::default()
+                .fg(theme::PEACH)
+                .add_modifier(Modifier::ITALIC),
         )));
     }
 
@@ -255,7 +266,10 @@ fn render_details(frame: &mut Frame, app: &App, s: &Strings, area: Rect) {
         for (label, color) in badges {
             spans.push(Span::styled(
                 format!(" ✦ {label} "),
-                Style::default().fg(theme::BASE).bg(color).add_modifier(Modifier::BOLD),
+                Style::default()
+                    .fg(theme::BASE)
+                    .bg(color)
+                    .add_modifier(Modifier::BOLD),
             ));
             spans.push(Span::raw(" "));
         }
@@ -292,10 +306,17 @@ fn render_details(frame: &mut Frame, app: &App, s: &Strings, area: Rect) {
 
         let indent = " ".repeat(label.chars().count());
         let budget = (info.width as usize).saturating_sub(label.chars().count());
-        for (row, text) in wrap_plain(&entries.join(" · "), budget.max(8)).into_iter().enumerate() {
+        for (row, text) in wrap_plain(&entries.join(" · "), budget.max(8))
+            .into_iter()
+            .enumerate()
+        {
             lines.push(Line::from(vec![
                 Span::styled(
-                    if row == 0 { label.clone() } else { indent.clone() },
+                    if row == 0 {
+                        label.clone()
+                    } else {
+                        indent.clone()
+                    },
                     Style::default().fg(theme::SUBTEXT),
                 ),
                 Span::styled(text, Style::default().fg(theme::TEXT)),
@@ -304,13 +325,19 @@ fn render_details(frame: &mut Frame, app: &App, s: &Strings, area: Rect) {
     }
 
     lines.push(Line::from(vec![
-        Span::styled(format!("{}: ", s.height_label), Style::default().fg(theme::SUBTEXT)),
+        Span::styled(
+            format!("{}: ", s.height_label),
+            Style::default().fg(theme::SUBTEXT),
+        ),
         Span::styled(
             format!("{:.1} m", detail.height as f32 / 10.0),
             Style::default().fg(theme::TEXT),
         ),
         Span::raw("    "),
-        Span::styled(format!("{}: ", s.weight_label), Style::default().fg(theme::SUBTEXT)),
+        Span::styled(
+            format!("{}: ", s.weight_label),
+            Style::default().fg(theme::SUBTEXT),
+        ),
         Span::styled(
             format!("{:.1} kg", detail.weight as f32 / 10.0),
             Style::default().fg(theme::TEXT),
@@ -321,12 +348,19 @@ fn render_details(frame: &mut Frame, app: &App, s: &Strings, area: Rect) {
     // Stat bars sized to the available width.
     let bar_width = (info.width as usize).saturating_sub(STAT_LABEL_WIDTH + 6);
     for stat in &detail.stats {
-        lines.push(stat_line(app.language.stat_label(stat.kind), stat.base, bar_width));
+        lines.push(stat_line(
+            app.language.stat_label(stat.kind),
+            stat.base,
+            bar_width,
+        ));
     }
 
     lines.push(Line::raw(""));
     lines.push(Line::from(vec![
-        Span::styled(format!("{}: ", s.total_label), Style::default().fg(theme::SUBTEXT)),
+        Span::styled(
+            format!("{}: ", s.total_label),
+            Style::default().fg(theme::SUBTEXT),
+        ),
         Span::styled(
             detail.stat_total().to_string(),
             Style::default()
@@ -349,8 +383,9 @@ fn render_details(frame: &mut Frame, app: &App, s: &Strings, area: Rect) {
     let flavor_rows = 4;
     match flavor {
         Some(flavor) if info.height as usize > lines.len() + flavor_rows => {
-            let split = Layout::vertical([Constraint::Min(0), Constraint::Length(flavor_rows as u16)])
-                .split(info);
+            let split =
+                Layout::vertical([Constraint::Min(0), Constraint::Length(flavor_rows as u16)])
+                    .split(info);
             frame.render_widget(Paragraph::new(lines), split[0]);
             render_flavor_card(frame, split[1], flavor);
         }
@@ -360,12 +395,12 @@ fn render_details(frame: &mut Frame, app: &App, s: &Strings, area: Rect) {
 
 /// Renders the Pokedex flavor-text blurb as a quoted, word-wrapped little card.
 fn render_flavor_card(frame: &mut Frame, area: Rect, flavor: &str) {
-    let para = Paragraph::new(vec![
-        Line::from(Span::styled(
-            format!("“{flavor}”"),
-            Style::default().fg(theme::SUBTEXT).add_modifier(Modifier::ITALIC),
-        )),
-    ])
+    let para = Paragraph::new(vec![Line::from(Span::styled(
+        format!("“{flavor}”"),
+        Style::default()
+            .fg(theme::SUBTEXT)
+            .add_modifier(Modifier::ITALIC),
+    ))])
     .wrap(Wrap { trim: true });
     frame.render_widget(para, area);
 }
@@ -423,8 +458,18 @@ fn render_sprite_capped(frame: &mut Frame, area: Rect, sprite: &Sprite, max_cols
     let sub_rows = 2 * rows as u32; // each cell row carries two vertical pixels
 
     // Source box covered by output column `cx` / sub-row `py`, in image pixels.
-    let span_x = |cx: u32| (bx0 + cx * bw / cols_u, bx0 + ((cx + 1) * bw / cols_u).saturating_sub(1));
-    let span_y = |py: u32| (by0 + py * bh / sub_rows, by0 + ((py + 1) * bh / sub_rows).saturating_sub(1));
+    let span_x = |cx: u32| {
+        (
+            bx0 + cx * bw / cols_u,
+            bx0 + ((cx + 1) * bw / cols_u).saturating_sub(1),
+        )
+    };
+    let span_y = |py: u32| {
+        (
+            by0 + py * bh / sub_rows,
+            by0 + ((py + 1) * bh / sub_rows).saturating_sub(1),
+        )
+    };
 
     let mut lines: Vec<Line> = Vec::with_capacity(rows as usize);
     for cy in 0..rows {
@@ -510,7 +555,9 @@ fn render_evolution(frame: &mut Frame, app: &App, s: &Strings, area: Rect) {
     // compact text tree so cramped terminals still show the relationships.
     if col_w >= MIN_CARD_W && lane_h >= MIN_CARD_H {
         let mut lane = 0u16;
-        place_node(frame, app, s, tree, current, cursor, canvas, col_w, lane_h, 0, &mut lane);
+        place_node(
+            frame, app, s, tree, current, cursor, canvas, col_w, lane_h, 0, &mut lane,
+        );
     } else {
         let lines = evolution_lines(tree, cursor.or(current), &s.evo, canvas.width);
         frame.render_widget(Paragraph::new(lines), canvas);
@@ -531,7 +578,11 @@ fn render_evolution(frame: &mut Frame, app: &App, s: &Strings, area: Rect) {
             Span::styled(text, Style::default().fg(theme::LAVENDER)),
         ]),
         None => Line::from(Span::styled(
-            if focused { s.evo_nav_hint } else { s.expand_hint },
+            if focused {
+                s.evo_nav_hint
+            } else {
+                s.expand_hint
+            },
             Style::default().fg(theme::OVERLAY),
         )),
     };
@@ -574,7 +625,10 @@ fn stat_line(label: &str, base: u16, bar_width: usize) -> Line<'static> {
             Style::default().fg(theme::SUBTEXT),
         ),
         Span::styled(format!("{base:>3} "), Style::default().fg(theme::TEXT)),
-        Span::styled("█".repeat(filled), Style::default().fg(theme::stat_color(base))),
+        Span::styled(
+            "█".repeat(filled),
+            Style::default().fg(theme::stat_color(base)),
+        ),
         Span::styled(
             "░".repeat(bar_width - filled),
             Style::default().fg(theme::SURFACE),
@@ -589,7 +643,10 @@ fn render_error(frame: &mut Frame, inner: Rect, s: &Strings, err: &str) {
             Style::default().fg(theme::RED).add_modifier(Modifier::BOLD),
         )),
         Line::raw(""),
-        Line::from(Span::styled(err.to_string(), Style::default().fg(theme::SUBTEXT))),
+        Line::from(Span::styled(
+            err.to_string(),
+            Style::default().fg(theme::SUBTEXT),
+        )),
     ])
     .wrap(ratatui::widgets::Wrap { trim: true });
     frame.render_widget(para, inner);
@@ -605,8 +662,11 @@ fn render_centered_text(frame: &mut Frame, inner: Rect, text: &str, color: ratat
         width: inner.width,
         height: 1,
     };
-    let para = Paragraph::new(Line::from(Span::styled(text.to_string(), Style::default().fg(color))))
-        .alignment(Alignment::Center);
+    let para = Paragraph::new(Line::from(Span::styled(
+        text.to_string(),
+        Style::default().fg(color),
+    )))
+    .alignment(Alignment::Center);
     frame.render_widget(para, row);
 }
 
@@ -700,8 +760,9 @@ fn node_block(
         let count = cur.children.len();
         for (i, child) in cur.children.iter().enumerate() {
             let is_last = i == count - 1;
-            for (j, child_row) in
-                node_block(child, highlight, evo, budget).into_iter().enumerate()
+            for (j, child_row) in node_block(child, highlight, evo, budget)
+                .into_iter()
+                .enumerate()
             {
                 let connector = if j == 0 {
                     if is_last {
@@ -742,7 +803,10 @@ fn truncate(text: &str, max: usize) -> String {
     if max <= 1 {
         return "…".to_string();
     }
-    text.chars().take(max - 1).chain(std::iter::once('…')).collect()
+    text.chars()
+        .take(max - 1)
+        .chain(std::iter::once('…'))
+        .collect()
 }
 
 fn name_span(raw_name: &str, highlight: Option<&str>) -> Span<'static> {
@@ -802,7 +866,17 @@ fn place_node(
         .iter()
         .map(|child| {
             place_node(
-                frame, app, s, child, current, cursor, canvas, col_w, lane_h, depth_idx + 1, lane,
+                frame,
+                app,
+                s,
+                child,
+                current,
+                cursor,
+                canvas,
+                col_w,
+                lane_h,
+                depth_idx + 1,
+                lane,
             )
         })
         .collect();
@@ -845,7 +919,12 @@ fn draw_card(
     let stacked = condition.is_some() && h > MIN_CARD_H;
     let text_rows = if stacked { 2 } else { 1 };
 
-    let sprite_area = Rect { x, y: top, width: w, height: h.saturating_sub(text_rows) };
+    let sprite_area = Rect {
+        x,
+        y: top,
+        width: w,
+        height: h.saturating_sub(text_rows),
+    };
     match app.sprites.get(&node.name) {
         Some(sprite) => render_sprite_capped(frame, sprite_area, sprite, w),
         None => {
@@ -866,7 +945,9 @@ fn draw_card(
             .bg(theme::YELLOW)
             .add_modifier(Modifier::BOLD)
     } else if is_current {
-        Style::default().fg(theme::YELLOW).add_modifier(Modifier::BOLD)
+        Style::default()
+            .fg(theme::YELLOW)
+            .add_modifier(Modifier::BOLD)
     } else {
         Style::default().fg(theme::GREEN)
     };
@@ -887,7 +968,15 @@ fn draw_card(
 
     let name_y = top + h.saturating_sub(text_rows);
     let name = Paragraph::new(Line::from(name_spans)).alignment(Alignment::Center);
-    frame.render_widget(name, Rect { x, y: name_y, width: w, height: 1 });
+    frame.render_widget(
+        name,
+        Rect {
+            x,
+            y: name_y,
+            width: w,
+            height: 1,
+        },
+    );
 
     if let (Some(text), true) = (&condition, stacked) {
         let requirement = Paragraph::new(Line::from(Span::styled(
@@ -895,7 +984,15 @@ fn draw_card(
             Style::default().fg(theme::PEACH),
         )))
         .alignment(Alignment::Center);
-        frame.render_widget(requirement, Rect { x, y: name_y + 1, width: w, height: 1 });
+        frame.render_widget(
+            requirement,
+            Rect {
+                x,
+                y: name_y + 1,
+                width: w,
+                height: 1,
+            },
+        );
     }
 }
 
@@ -930,7 +1027,11 @@ fn draw_connectors(frame: &mut Frame, x_from: u16, x_to: u16, parent_cy: u16, ce
         put_cell(frame, trunk_x, y, "│", color);
     }
     // Junction where the parent's stub meets the trunk.
-    let junction = if centers.contains(&parent_cy) { "┼" } else { "┤" };
+    let junction = if centers.contains(&parent_cy) {
+        "┼"
+    } else {
+        "┤"
+    };
     put_cell(frame, trunk_x, parent_cy, junction, color);
 
     // Branch off to each child and tip it with an arrowhead.
@@ -995,7 +1096,9 @@ fn render_matchups(frame: &mut Frame, app: &App, s: &Strings, full: Rect) {
     // Headline: who this card is about, and the types the analysis is based on.
     let mut head = vec![Span::styled(
         format!(" {}  ", title_case(&detail.name)),
-        Style::default().fg(theme::MAUVE).add_modifier(Modifier::BOLD),
+        Style::default()
+            .fg(theme::MAUVE)
+            .add_modifier(Modifier::BOLD),
     )];
     head.extend(type_chips(&detail.types));
     lines.push(Line::from(head));
@@ -1031,7 +1134,9 @@ fn render_matchups(frame: &mut Frame, app: &App, s: &Strings, full: Rect) {
         .border_style(Style::default().fg(theme::MAUVE))
         .title(Span::styled(
             s.matchups_title,
-            Style::default().fg(theme::MAUVE).add_modifier(Modifier::BOLD),
+            Style::default()
+                .fg(theme::MAUVE)
+                .add_modifier(Modifier::BOLD),
         ))
         .style(Style::default().bg(theme::SURFACE));
     let inner = block.inner(area);
@@ -1064,7 +1169,9 @@ fn type_chips(types: &[String]) -> Vec<Span<'static>> {
 fn section_heading(text: &str) -> Line<'static> {
     Line::from(Span::styled(
         format!(" {text}"),
-        Style::default().fg(theme::PEACH).add_modifier(Modifier::BOLD),
+        Style::default()
+            .fg(theme::PEACH)
+            .add_modifier(Modifier::BOLD),
     ))
 }
 
@@ -1076,7 +1183,9 @@ fn chip_rows(label: &str, types: &[&str], max_width: usize) -> Vec<Line<'static>
     let mut rows: Vec<Line> = Vec::new();
     let mut spans: Vec<Span> = vec![Span::styled(
         format!(" {label:<pad$} ", pad = MATCHUP_LABEL_W - 2),
-        Style::default().fg(theme::SUBTEXT).add_modifier(Modifier::BOLD),
+        Style::default()
+            .fg(theme::SUBTEXT)
+            .add_modifier(Modifier::BOLD),
     )];
     let mut used = MATCHUP_LABEL_W;
 
@@ -1165,15 +1274,17 @@ fn render_help(frame: &mut Frame, s: &Strings, full: Rect) {
         .border_style(Style::default().fg(theme::MAUVE))
         .title(Span::styled(
             h.title,
-            Style::default().fg(theme::MAUVE).add_modifier(Modifier::BOLD),
+            Style::default()
+                .fg(theme::MAUVE)
+                .add_modifier(Modifier::BOLD),
         ))
         .style(Style::default().bg(theme::SURFACE));
     let inner = block.inner(area);
     frame.render_widget(block, area);
 
     let body = Layout::vertical([Constraint::Min(0), Constraint::Length(1)]).split(inner);
-    let cols = Layout::horizontal([Constraint::Percentage(50), Constraint::Percentage(50)])
-        .split(body[0]);
+    let cols =
+        Layout::horizontal([Constraint::Percentage(50), Constraint::Percentage(50)]).split(body[0]);
     frame.render_widget(Paragraph::new(help_lines(&left)), cols[0]);
     frame.render_widget(Paragraph::new(help_lines(&right)), cols[1]);
 
@@ -1210,7 +1321,9 @@ fn help_lines(rows: &[(&str, &str)]) -> Vec<Line<'static>> {
             Line::from(vec![
                 Span::styled(
                     format!("  {keys:<key_w$}"),
-                    Style::default().fg(theme::TEAL).add_modifier(Modifier::BOLD),
+                    Style::default()
+                        .fg(theme::TEAL)
+                        .add_modifier(Modifier::BOLD),
                 ),
                 Span::styled((*action).to_string(), Style::default().fg(theme::SUBTEXT)),
             ])
@@ -1234,7 +1347,9 @@ fn render_abilities(frame: &mut Frame, app: &App, s: &Strings, full: Rect) {
 
     lines.push(Line::from(Span::styled(
         format!(" {}", title_case(&detail.name)),
-        Style::default().fg(theme::MAUVE).add_modifier(Modifier::BOLD),
+        Style::default()
+            .fg(theme::MAUVE)
+            .add_modifier(Modifier::BOLD),
     )));
 
     for ability in &detail.abilities {
@@ -1242,7 +1357,9 @@ fn render_abilities(frame: &mut Frame, app: &App, s: &Strings, full: Rect) {
 
         let mut head = vec![Span::styled(
             format!(" {}", ability_display_name(app, &ability.name)),
-            Style::default().fg(theme::PEACH).add_modifier(Modifier::BOLD),
+            Style::default()
+                .fg(theme::PEACH)
+                .add_modifier(Modifier::BOLD),
         )];
         if ability.is_hidden {
             head.push(Span::styled(
@@ -1254,7 +1371,11 @@ fn render_abilities(frame: &mut Frame, app: &App, s: &Strings, full: Rect) {
 
         // Until the text lands — or if it never does — the name above is still
         // the useful half, so the row degrades to a quiet placeholder.
-        match app.abilities.get(&ability.name).and_then(|info| info.flavor_for(code)) {
+        match app
+            .abilities
+            .get(&ability.name)
+            .and_then(|info| info.flavor_for(code))
+        {
             Some(text) => {
                 for row in wrap_plain(text, text_w) {
                     lines.push(Line::from(Span::styled(
@@ -1279,7 +1400,9 @@ fn render_abilities(frame: &mut Frame, app: &App, s: &Strings, full: Rect) {
         .border_style(Style::default().fg(theme::MAUVE))
         .title(Span::styled(
             s.abilities_title,
-            Style::default().fg(theme::MAUVE).add_modifier(Modifier::BOLD),
+            Style::default()
+                .fg(theme::MAUVE)
+                .add_modifier(Modifier::BOLD),
         ))
         .style(Style::default().bg(theme::SURFACE));
     let inner = block.inner(area);
@@ -1337,7 +1460,9 @@ fn render_team(frame: &mut Frame, app: &App, s: &Strings, full: Rect) {
 
     lines.push(Line::from(Span::styled(
         format!(" {}/{}", app.team.len(), team::MAX_MEMBERS),
-        Style::default().fg(theme::MAUVE).add_modifier(Modifier::BOLD),
+        Style::default()
+            .fg(theme::MAUVE)
+            .add_modifier(Modifier::BOLD),
     )));
     lines.push(Line::raw(""));
 
@@ -1441,7 +1566,9 @@ fn render_team(frame: &mut Frame, app: &App, s: &Strings, full: Rect) {
         .border_style(Style::default().fg(theme::MAUVE))
         .title(Span::styled(
             s.team_title,
-            Style::default().fg(theme::MAUVE).add_modifier(Modifier::BOLD),
+            Style::default()
+                .fg(theme::MAUVE)
+                .add_modifier(Modifier::BOLD),
         ))
         .style(Style::default().bg(theme::SURFACE));
     let inner = block.inner(area);
@@ -1487,7 +1614,9 @@ fn render_language_picker(frame: &mut Frame, app: &App, s: &Strings, full: Rect)
         .border_style(Style::default().fg(theme::MAUVE))
         .title(Span::styled(
             s.language_title,
-            Style::default().fg(theme::MAUVE).add_modifier(Modifier::BOLD),
+            Style::default()
+                .fg(theme::MAUVE)
+                .add_modifier(Modifier::BOLD),
         ))
         .style(Style::default().bg(theme::SURFACE));
     let inner = block.inner(area);


### PR DESCRIPTION
Closes #1.

The repository had no `.github/` directory and no automated checks — nothing verified that a change compiled, passed the suite, or matched the project's formatting before it landed on `main`.

## What's here

**`0081261` — `cargo fmt` across the codebase.** Purely mechanical, the output of `cargo fmt --all` with default rustfmt settings, touching 6 files. Kept as its own commit so the reformatting churn does not bury the workflow being added. **Review the second commit; this one is machine-generated.**

**`810da12` — the workflows.**

`ci.yml` runs on pushes to `main` and on every PR:

| Job | What it runs |
|---|---|
| `fmt` | `cargo fmt --all --check` |
| `clippy` | `cargo clippy --all-targets --all-features -- -D warnings` |
| `test` | `cargo test --all-features` on Linux, macOS and Windows |
| `msrv` | `cargo check` against the `rust-version` floor |

`audit.yml` runs `cargo deny check advisories licenses bans sources`, on manifest changes and weekly on a schedule — an advisory lands when it is published, not when we happen to push.

## Notes for review

**The MSRV is 1.88**, now declared in `Cargo.toml`. It is set by our dependency floor — `image` and `darling` both require it — rather than by any language feature we use. I verified it locally against a real 1.88 toolchain (`cargo +1.88 check --all-targets`) rather than inferring it, so the job should be green on the first run. The `msrv` job reads the value out of `Cargo.toml` instead of hardcoding it, so bumping the floor is a one-line manifest change.

**The license allowlist in `deny.toml`** was derived from the actual dependency tree, not guessed. Two entries are worth flagging: `r-efi` offers `LGPL-2.1-or-later` and `adler2` offers `0BSD`, but both are dual-licensed with permissive alternatives, so nothing copyleft is binding on a distributed binary.

**`test` uses `fail-fast: false`** so a Windows-only failure does not cancel the Linux and macOS jobs and cost us a diagnosis.

## Verification

`cargo fmt --check`, `cargo clippy -- -D warnings` and all 44 tests pass locally on both stable (1.95) and 1.88.

## Follow-ups, not in scope here

Release automation and a changelog are #7, which depends on this.
