### PR TITLE
Make the API client resilient: timeouts, bounded retries, concurrency cap

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -5,15 +5,38 @@
 //! kept private so the JSON shape never leaks out of this module.
 
 use std::collections::HashMap;
+use std::sync::OnceLock;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use tokio::sync::Semaphore;
 
 use crate::models::{
     Ability, AbilityInfo, EvolutionCondition, EvolutionTree, EvolutionTrigger, PokemonDetail,
     PokemonEntry, Sprite, Stat, StatKind,
 };
+use crate::retry::{self, FailureKind};
 
 const BASE_URL: &str = "https://pokeapi.co/api/v2";
 /// How many Pokemon to load into the sidebar. Covers all current species.
 const LIST_LIMIT: u32 = 1302;
+
+/// Ceiling on requests in flight at once across the whole process.
+///
+/// Fetches are dispatched from independent tasks that know nothing about each
+/// other, so without a shared limit a single keypress can produce a burst: an
+/// evolution chain requests a sprite per member, and Eevee's is nine. PokeAPI
+/// asks clients to be considerate of its fair-use policy, and this is where we
+/// hold ourselves to it.
+const MAX_CONCURRENT_REQUESTS: usize = 6;
+
+/// How long to wait for a connection to establish before giving up on it.
+const CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// How long any single attempt may take end to end. `reqwest` applies no
+/// timeout of its own, so without this a connection that opens and then stalls
+/// leaves the request pending forever — and the UI showing a load that can
+/// never resolve.
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(15);
 
 /// Errors that can occur while talking to PokeAPI.
 #[derive(Debug, thiserror::Error)]
@@ -30,20 +53,101 @@ pub enum ApiError {
 pub fn build_client() -> Result<reqwest::Client, ApiError> {
     let client = reqwest::Client::builder()
         .user_agent(concat!("pokeductor/", env!("CARGO_PKG_VERSION")))
+        .connect_timeout(CONNECT_TIMEOUT)
+        .timeout(REQUEST_TIMEOUT)
         .build()?;
     Ok(client)
+}
+
+/// The process-wide cap on in-flight requests.
+///
+/// A `static` rather than a field on the client because the limit belongs to
+/// PokeAPI, not to any one caller: every task must queue behind the same
+/// permits for the cap to mean anything.
+fn request_permits() -> &'static Semaphore {
+    static PERMITS: OnceLock<Semaphore> = OnceLock::new();
+    PERMITS.get_or_init(|| Semaphore::new(MAX_CONCURRENT_REQUESTS))
+}
+
+/// Sorts a `reqwest` failure into the classes the retry policy reasons about.
+fn classify(err: &reqwest::Error) -> FailureKind {
+    if let Some(status) = err.status() {
+        return FailureKind::Status(status.as_u16());
+    }
+    if err.is_decode() {
+        return FailureKind::Decode;
+    }
+    // Timeouts, connection failures, redirect loops and DNS errors all mean no
+    // usable response arrived, which is the case worth another attempt.
+    FailureKind::Transport
+}
+
+/// A uniform draw from `[0, 1)` for the backoff jitter.
+///
+/// Taken from the clock rather than from `rand`: the requirement is that
+/// simultaneous retries stop colliding, which nanosecond scheduling noise
+/// satisfies, and it is not worth a dependency for that.
+fn jitter_fraction() -> f64 {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.subsec_nanos())
+        .unwrap_or(0);
+    f64::from(nanos) / f64::from(1_000_000_000u32)
+}
+
+/// Sends a request, retrying transient failures, and returns the successful
+/// response.
+///
+/// Takes a closure rather than a `RequestBuilder` because a builder is consumed
+/// by `send` and each attempt needs a fresh one. The concurrency permit is
+/// acquired per attempt, so a task waiting out a backoff is not holding a slot
+/// another task could be using.
+async fn send_with_retry<F>(build: F) -> Result<reqwest::Response, ApiError>
+where
+    F: Fn() -> reqwest::RequestBuilder,
+{
+    let mut attempt = 0;
+    loop {
+        let result = {
+            // `request_permits` is never closed, so acquisition cannot fail.
+            let _permit = request_permits().acquire().await;
+            build().send().await.and_then(|r| r.error_for_status())
+        };
+
+        let err = match result {
+            Ok(response) => return Ok(response),
+            Err(err) => err,
+        };
+
+        let last_attempt = attempt + 1 >= retry::MAX_ATTEMPTS;
+        if last_attempt || !retry::is_retryable(classify(&err)) {
+            return Err(ApiError::Network(err));
+        }
+
+        tokio::time::sleep(retry::backoff_delay(attempt, jitter_fraction())).await;
+        attempt += 1;
+    }
+}
+
+/// `GET` a URL and deserialize the JSON body.
+async fn get_json<T: serde::de::DeserializeOwned>(
+    client: &reqwest::Client,
+    url: &str,
+) -> Result<T, ApiError> {
+    let response = send_with_retry(|| client.get(url)).await?;
+    Ok(response.json().await?)
+}
+
+/// `GET` a URL and return the raw body.
+async fn get_bytes(client: &reqwest::Client, url: &str) -> Result<Vec<u8>, ApiError> {
+    let response = send_with_retry(|| client.get(url)).await?;
+    Ok(response.bytes().await?.to_vec())
 }
 
 /// Fetches the master list of Pokemon names for the sidebar.
 pub async fn fetch_pokemon_list(client: &reqwest::Client) -> Result<Vec<PokemonEntry>, ApiError> {
     let url = format!("{BASE_URL}/pokemon?limit={LIST_LIMIT}&offset=0");
-    let raw: NamedList = client
-        .get(url)
-        .send()
-        .await?
-        .error_for_status()?
-        .json()
-        .await?;
+    let raw: NamedList = get_json(client, &url).await?;
     let entries = raw
         .results
         .into_iter()
@@ -65,13 +169,7 @@ pub async fn fetch_type_members(
     type_name: &str,
 ) -> Result<Vec<String>, ApiError> {
     let url = format!("{BASE_URL}/type/{type_name}");
-    let raw: RawType = client
-        .get(url)
-        .send()
-        .await?
-        .error_for_status()?
-        .json()
-        .await?;
+    let raw: RawType = get_json(client, &url).await?;
     Ok(raw.pokemon.into_iter().map(|p| p.pokemon.name).collect())
 }
 
@@ -132,14 +230,13 @@ pub async fn translate_text(
     // well under that, but clamp defensively just in case.
     let clamped: String = text.chars().take(500).collect();
     let pair = format!("{from}|{to}");
-    let resp: MyMemoryResponse = client
-        .get("https://api.mymemory.translated.net/get")
-        .query(&[("q", clamped.as_str()), ("langpair", pair.as_str())])
-        .send()
-        .await?
-        .error_for_status()?
-        .json()
-        .await?;
+    let response = send_with_retry(|| {
+        client
+            .get("https://api.mymemory.translated.net/get")
+            .query(&[("q", clamped.as_str()), ("langpair", pair.as_str())])
+    })
+    .await?;
+    let resp: MyMemoryResponse = response.json().await?;
     Ok(resp.response_data.translated_text)
 }
 
@@ -150,13 +247,7 @@ pub async fn translate_text(
 /// while effect text exists only in English, German and French.
 pub async fn fetch_ability(client: &reqwest::Client, name: &str) -> Result<AbilityInfo, ApiError> {
     let url = format!("{BASE_URL}/ability/{name}");
-    let raw: RawAbility = client
-        .get(url)
-        .send()
-        .await?
-        .error_for_status()?
-        .json()
-        .await?;
+    let raw: RawAbility = get_json(client, &url).await?;
 
     let mut names = HashMap::new();
     for n in &raw.names {
@@ -200,13 +291,7 @@ pub async fn fetch_named_sprite(
 
 /// Downloads a sprite PNG and decodes it into raw RGBA pixels.
 pub async fn fetch_sprite(client: &reqwest::Client, url: &str) -> Result<Sprite, ApiError> {
-    let bytes = client
-        .get(url)
-        .send()
-        .await?
-        .error_for_status()?
-        .bytes()
-        .await?;
+    let bytes = get_bytes(client, url).await?;
     let image = image::load_from_memory(&bytes)?.to_rgba8();
     let (width, height) = image.dimensions();
     let pixels = image.pixels().map(|p| p.0).collect();
@@ -219,13 +304,7 @@ pub async fn fetch_sprite(client: &reqwest::Client, url: &str) -> Result<Sprite,
 
 async fn fetch_detail(client: &reqwest::Client, name: &str) -> Result<PokemonDetail, ApiError> {
     let url = format!("{BASE_URL}/pokemon/{name}");
-    let raw: RawPokemon = client
-        .get(url)
-        .send()
-        .await?
-        .error_for_status()?
-        .json()
-        .await?;
+    let raw: RawPokemon = get_json(client, &url).await?;
 
     let mut types: Vec<(u8, String)> = raw
         .types
@@ -301,13 +380,7 @@ struct SpeciesInfo {
 /// and flavor text in every language we care about for the info card.
 async fn fetch_species(client: &reqwest::Client, name: &str) -> Result<SpeciesInfo, ApiError> {
     let url = format!("{BASE_URL}/pokemon-species/{name}");
-    let species: RawSpecies = client
-        .get(url)
-        .send()
-        .await?
-        .error_for_status()?
-        .json()
-        .await?;
+    let species: RawSpecies = get_json(client, &url).await?;
 
     let chain_url = species
         .evolution_chain
@@ -347,13 +420,7 @@ async fn fetch_species(client: &reqwest::Client, name: &str) -> Result<SpeciesIn
 
 /// Fetches and parses an evolution chain from its API URL.
 async fn fetch_chain(client: &reqwest::Client, url: &str) -> Result<EvolutionTree, ApiError> {
-    let chain: RawEvolutionChain = client
-        .get(url)
-        .send()
-        .await?
-        .error_for_status()?
-        .json()
-        .await?;
+    let chain: RawEvolutionChain = get_json(client, url).await?;
     Ok(parse_chain(&chain.chain))
 }
 
@@ -575,6 +642,49 @@ struct MyMemoryData {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// End-to-end check against the live API, covering the whole request path:
+    /// the permit, the retry wrapper, the real timeouts, and parsing a payload
+    /// nobody wrote by hand.
+    ///
+    /// Ignored by default so neither CI nor a routine `cargo test` depends on
+    /// the network or spends PokeAPI's quota. Run it deliberately after
+    /// touching this module:
+    ///
+    /// ```text
+    /// cargo test --all-features -- --ignored --nocapture
+    /// ```
+    #[tokio::test]
+    #[ignore = "requires network access to pokeapi.co"]
+    async fn the_live_api_still_answers() {
+        let client = build_client().expect("client builds");
+
+        let list = fetch_pokemon_list(&client).await.expect("list fetch");
+        assert!(list.len() > 1000, "got {} entries", list.len());
+
+        let (detail, tree, sprite) = fetch_pokemon_bundle(&client, "eevee")
+            .await
+            .expect("bundle fetch");
+        assert_eq!(detail.name, "eevee");
+        assert!(detail.types.contains(&"normal".to_string()));
+        assert!(sprite.is_some(), "eevee should have artwork");
+        assert!(
+            tree.leaf_count() >= 8,
+            "eevee branches {} ways",
+            tree.leaf_count()
+        );
+
+        // A name that does not exist must fail fast rather than burn the full
+        // retry budget on an answer that will not change.
+        let started = std::time::Instant::now();
+        let missing = fetch_pokemon_bundle(&client, "missingno-not-a-species").await;
+        assert!(missing.is_err(), "a bogus species should not resolve");
+        assert!(
+            started.elapsed() < REQUEST_TIMEOUT,
+            "a 404 took {:?}, so it was retried",
+            started.elapsed()
+        );
+    }
 
     /// A trimmed `/evolution-chain` payload in the exact shape PokeAPI sends:
     /// Eevee branching into an item evolution and a conditional one.

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,7 @@
 //! - `theme`   : Catppuccin Mocha palette and per-type colors.
 //! - `api`     : async PokeAPI client and evolution-chain parser.
 //! - `query`   : search-box syntax (`type:`, `gen:`) parsing.
+//! - `retry`   : retry classification and backoff policy for network requests.
 //! - `typechart`: offline type-effectiveness chart.
 //! - `team`    : team-level type analysis built on top of it.
 //! - `app`     : state machine + `tokio::select!` event loop.
@@ -18,6 +19,7 @@ mod cache;
 mod i18n;
 mod models;
 mod query;
+mod retry;
 mod team;
 mod theme;
 mod typechart;

--- a/src/retry.rs
+++ b/src/retry.rs
@@ -1,0 +1,164 @@
+//! Retry policy for network requests.
+//!
+//! The decision-making lives here, apart from the code that performs the I/O,
+//! so it can be exercised directly: both functions below are pure, and
+//! `backoff_delay` takes its randomness as an argument rather than drawing it
+//! internally. `api.rs` supplies the jitter and does the waiting.
+
+use std::time::Duration;
+
+/// How many times a single request is attempted before giving up. Four means
+/// three retries after the first try, which is enough to ride out a transient
+/// blip without leaving the user watching a spinner through a real outage.
+pub const MAX_ATTEMPTS: u32 = 4;
+
+/// Base delay for the backoff schedule.
+pub const BACKOFF_BASE: Duration = Duration::from_millis(250);
+
+/// Ceiling on any single backoff delay. This is an interactive TUI: a user who
+/// pressed a key is waiting, so the schedule is deliberately shorter than a
+/// batch client's would be.
+pub const BACKOFF_CAP: Duration = Duration::from_secs(4);
+
+/// The failure classes we distinguish when deciding whether to try again.
+///
+/// Derived from a `reqwest::Error` at the call site rather than matched on
+/// directly, because `reqwest::Error` cannot be constructed in a test.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FailureKind {
+    /// Timed out, or the connection never established. No response arrived.
+    Transport,
+    /// The server responded with this status code.
+    Status(u16),
+    /// A response arrived but could not be decoded into the expected shape.
+    Decode,
+}
+
+/// Whether a failed attempt is worth repeating.
+///
+/// Every request this client makes is an idempotent `GET`, so the question is
+/// only whether the failure is likely to be transient — not whether repeating
+/// it is safe.
+pub fn is_retryable(kind: FailureKind) -> bool {
+    match kind {
+        // Nothing was received, so nothing was learned. Worth another look.
+        FailureKind::Transport => true,
+        // 5xx is the server having a bad moment; 429 is it asking us to slow
+        // down, which is a request to come back later rather than a refusal.
+        // Every other status is a definitive answer — a 404 for a species that
+        // does not exist is *correct*, and asking three more times wastes the
+        // user's time and PokeAPI's.
+        FailureKind::Status(code) => code >= 500 || code == 429,
+        // Re-fetching will not make a malformed payload parse. That is our bug
+        // or a breaking API change, and retrying only delays the report.
+        FailureKind::Decode => false,
+    }
+}
+
+/// Delay before the retry following `attempt` (0-based), using full jitter.
+///
+/// The exponential ceiling doubles per attempt up to [`BACKOFF_CAP`], and the
+/// actual delay is a uniform draw from zero to that ceiling. Picking a point in
+/// the range rather than adding a small wobble to a fixed delay is what
+/// decorrelates clients — and it matters here even for one user, because a
+/// branching evolution chain dispatches its sprite requests together, so their
+/// failures and therefore their retries would otherwise land in lockstep.
+///
+/// `jitter` is the caller's uniform draw from `[0, 1)`; values outside that
+/// range are clamped.
+pub fn backoff_delay(attempt: u32, jitter: f64) -> Duration {
+    let ceiling = BACKOFF_BASE
+        .saturating_mul(2u32.saturating_pow(attempt.min(16)))
+        .min(BACKOFF_CAP);
+    ceiling.mul_f64(jitter.clamp(0.0, 1.0))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_missing_species_is_not_retried() {
+        assert!(!is_retryable(FailureKind::Status(404)));
+    }
+
+    #[test]
+    fn client_errors_are_final() {
+        for code in [400, 401, 403, 404, 410, 418] {
+            assert!(!is_retryable(FailureKind::Status(code)), "{code}");
+        }
+    }
+
+    #[test]
+    fn server_errors_are_retried() {
+        for code in [500, 502, 503, 504] {
+            assert!(is_retryable(FailureKind::Status(code)), "{code}");
+        }
+    }
+
+    #[test]
+    fn being_rate_limited_is_retried() {
+        assert!(is_retryable(FailureKind::Status(429)));
+    }
+
+    #[test]
+    fn a_success_status_is_never_classified_as_retryable() {
+        assert!(!is_retryable(FailureKind::Status(200)));
+        assert!(!is_retryable(FailureKind::Status(304)));
+    }
+
+    #[test]
+    fn timeouts_and_connection_failures_are_retried() {
+        assert!(is_retryable(FailureKind::Transport));
+    }
+
+    #[test]
+    fn a_malformed_body_is_not_retried() {
+        // Re-fetching will not make the payload parse; this is our bug or a
+        // breaking API change, and retrying only delays the error.
+        assert!(!is_retryable(FailureKind::Decode));
+    }
+
+    #[test]
+    fn the_backoff_ceiling_doubles_per_attempt() {
+        // Jitter of 1.0 draws the top of the range, which is the ceiling.
+        assert_eq!(backoff_delay(0, 1.0), BACKOFF_BASE);
+        assert_eq!(backoff_delay(1, 1.0), BACKOFF_BASE * 2);
+        assert_eq!(backoff_delay(2, 1.0), BACKOFF_BASE * 4);
+    }
+
+    #[test]
+    fn the_delay_never_exceeds_the_cap() {
+        for attempt in 0..64 {
+            assert!(backoff_delay(attempt, 1.0) <= BACKOFF_CAP, "{attempt}");
+        }
+    }
+
+    #[test]
+    fn every_delay_stays_within_its_jittered_range() {
+        for attempt in 0..8 {
+            let ceiling = backoff_delay(attempt, 1.0);
+            for step in 0..=10 {
+                let delay = backoff_delay(attempt, step as f64 / 10.0);
+                assert!(delay <= ceiling, "attempt {attempt}, step {step}");
+            }
+        }
+    }
+
+    #[test]
+    fn full_jitter_can_draw_the_bottom_of_the_range() {
+        assert_eq!(backoff_delay(3, 0.0), Duration::ZERO);
+    }
+
+    #[test]
+    fn jitter_outside_the_unit_range_is_clamped() {
+        assert_eq!(backoff_delay(1, 5.0), backoff_delay(1, 1.0));
+        assert_eq!(backoff_delay(1, -5.0), backoff_delay(1, 0.0));
+    }
+
+    #[test]
+    fn a_large_attempt_number_does_not_overflow() {
+        // Saturating arithmetic rather than a panic in release-mode wrapping.
+        assert_eq!(backoff_delay(u32::MAX, 1.0), BACKOFF_CAP);
+    }
+}


### PR DESCRIPTION
Closes #2.

> **Stacked on #8** — based on `ci/github-actions` so it inherits the formatting commit. Review the top commit only; it rebases cleanly onto `main` once #8 lands.

`build_client()` was configured with a user agent and nothing else. Three problems followed.

## What was wrong

**No timeout.** `reqwest` applies none by default, so a connection that opened and then stalled left the request pending forever. `App` tracks work in flight by name, so the UI showed a load that could never resolve and offered the user no way out.

**No retries.** Every call site treated its first failure as final. A transient DNS blip or a single 502 became a hard error where a second attempt would almost certainly have succeeded.

**No concurrency limit.** Fetches are dispatched from seven independent `tokio::spawn` sites that cannot see each other, so bursts were unbounded — opening Eevee fires one sprite request per chain member, nine at once. The README asks readers to respect PokeAPI's fair-use policy; this holds us to it in code.

## What's here

- Connect and total request timeouts on the client.
- Full-jitter exponential backoff, capped at 4s per delay, 4 attempts total.
- **4xx is never retried.** A 404 for a species that does not exist is a *correct* answer, and retrying it wastes the user's time and PokeAPI's. Retries are limited to transport failures, 5xx and 429.
- A process-wide `Semaphore` capping requests in flight. The permit is acquired **per attempt**, so a task waiting out a backoff is not sitting on a slot another task could use.
- The nine call sites now share two helpers rather than each repeating the `send`/`error_for_status`/decode chain — which is what makes the policy apply everywhere instead of wherever it was remembered.

## On testing this

The interesting part of retry logic is the decision-making, and that is the part usually left untested because it is tangled up with I/O. So the policy lives in a new `retry` module holding two pure functions, with the jitter **passed in** rather than drawn internally — which makes the backoff schedule deterministic and directly assertable. 13 unit tests cover the classification, the doubling ceiling, the cap, and the jitter bounds, with no network and no mock server.

There is also an **end-to-end test against the live API** (`api::tests::the_live_api_still_answers`), `#[ignore]`d so neither CI nor a routine `cargo test` depends on the network. It exercises the real path — permit, retry wrapper, real timeouts, real payloads — and asserts that a missing species fails fast rather than burning the retry budget. I ran it against live PokeAPI while developing this; it passes in ~3s, which is itself the evidence that the 404 is not being retried.

## Why jitter, for a single-user TUI

Jitter is usually justified by thundering-herd across many clients, which does not obviously apply here. It still matters: an evolution chain requests its sprites together, so they fail together, and without jitter their retries would re-collide on exactly the same schedule. Full jitter (a uniform draw from zero to the ceiling) rather than a wobble around a fixed delay is what actually decorrelates them.

The jitter source is the clock rather than `rand` — the requirement is only that simultaneous retries stop colliding, and that is not worth a dependency.

## Verification

`cargo fmt --check`, `cargo clippy -- -D warnings`, and 57 tests (44 existing + 13 new) pass. The live test passes against PokeAPI.

## Open question for review

`MAX_CONCURRENT_REQUESTS` is 6 and `MAX_ATTEMPTS` is 4 — both picked as sane defaults rather than measured. Happy to adjust if you have a view on what PokeAPI actually tolerates.
