### PR TITLE
Add an app-wide shiny artwork toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,19 @@ panel falls back to a labelled list rather than truncating:
 
 <img src="https://raw.githubusercontent.com/Huseynteymurzade28/pokeductor/main/assets/ui-branching.png" alt="Eevee's eight-way evolution chain listed with the requirement for each branch" width="900">
 
+### Shiny artwork
+
+`X` flips every sprite on screen — the info panel and each card in the
+evolution chain — into its shiny palette, so a whole line can be inspected in
+the colours it is hunted for. The toggle is app-wide rather than per-species:
+it stays on as you move through the list, and the info panel carries a
+`✦ Shiny` badge while it does, since an unfamiliar palette otherwise reads as a
+rendering bug.
+
+Only the palette on screen is fetched, so flipping the toggle never pulls down
+two full sets of artwork, and both are cached separately on disk. A species
+PokeAPI ships no shiny sprite for falls back to its normal one.
+
 ### Type matchups
 
 `T` opens the defensive and offensive breakdown for the current species:
@@ -170,6 +183,7 @@ no refetch:
 | | `E` | Focus the evolution panel |
 | | `T` | Type matchup card |
 | | `A` | Ability card |
+| | `X` | Toggle shiny artwork |
 | | `Space` | Add / remove from the party |
 | | `P` | Party card |
 | | `S` | Cycle sort: Pokédex order ↔ A–Z |
@@ -181,6 +195,7 @@ no refetch:
 | | `Esc` · `Tab` | Back to the list |
 | **Evolution panel** | `←` `→` `↑` `↓` · `h` `j` `k` `l` | Move between stages |
 | | `Enter` | Jump to the highlighted stage |
+| | `X` | Toggle shiny artwork |
 | | `Esc` · `Tab` | Back to the list |
 | **Any card** | `Esc` | Close |
 | **Anywhere** | `Ctrl-C` | Quit |

--- a/src/api.rs
+++ b/src/api.rs
@@ -12,7 +12,7 @@ use tokio::sync::Semaphore;
 
 use crate::models::{
     Ability, AbilityInfo, EvolutionCondition, EvolutionTree, EvolutionTrigger, PokemonDetail,
-    PokemonEntry, Sprite, Stat, StatKind,
+    PokemonEntry, Sprite, SpriteVariant, Stat, StatKind,
 };
 use crate::retry::{self, FailureKind};
 
@@ -190,6 +190,7 @@ fn id_from_url(url: &str) -> u32 {
 pub async fn fetch_pokemon_bundle(
     client: &reqwest::Client,
     name: &str,
+    variant: SpriteVariant,
 ) -> Result<(PokemonDetail, EvolutionTree, Option<Sprite>), ApiError> {
     let mut detail = fetch_detail(client, name).await?;
 
@@ -207,8 +208,10 @@ pub async fn fetch_pokemon_bundle(
     let evolution = fetch_chain(client, &species.chain_url).await?;
 
     // The sprite is a nice-to-have: a missing or undecodable image must not
-    // sink the whole bundle, so failures here degrade to "no sprite".
-    let sprite = match &detail.sprite_url {
+    // sink the whole bundle, so failures here degrade to "no sprite". Only the
+    // palette currently on screen is fetched; the other one waits until the
+    // shiny toggle actually asks for it.
+    let sprite = match detail.sprite_url_for(variant) {
         Some(url) => fetch_sprite(client, url).await.ok(),
         None => None,
     };
@@ -276,15 +279,17 @@ pub async fn fetch_ability(client: &reqwest::Client, name: &str) -> Result<Abili
     })
 }
 
-/// Fetches and decodes just the sprite for a named species. Used to lazily
-/// populate the evolution overlay, where every member of the chain needs art.
+/// Fetches and decodes just the sprite for a named species, in the requested
+/// palette. Used to lazily populate the evolution overlay, where every member
+/// of the chain needs art.
 pub async fn fetch_named_sprite(
     client: &reqwest::Client,
     name: &str,
+    variant: SpriteVariant,
 ) -> Result<Option<Sprite>, ApiError> {
     let detail = fetch_detail(client, name).await?;
-    match detail.sprite_url {
-        Some(url) => Ok(Some(fetch_sprite(client, &url).await?)),
+    match detail.sprite_url_for(variant) {
+        Some(url) => Ok(Some(fetch_sprite(client, url).await?)),
         None => Ok(None),
     }
 }
@@ -355,6 +360,7 @@ async fn fetch_detail(client: &reqwest::Client, name: &str) -> Result<PokemonDet
         height: raw.height,
         weight: raw.weight,
         sprite_url: raw.sprites.front_default,
+        shiny_sprite_url: raw.sprites.front_shiny,
         genera: HashMap::new(),
         flavors: HashMap::new(),
     })
@@ -541,6 +547,8 @@ struct RawPokemon {
 struct RawSprites {
     #[serde(default)]
     front_default: Option<String>,
+    #[serde(default)]
+    front_shiny: Option<String>,
 }
 
 #[derive(serde::Deserialize)]
@@ -662,12 +670,16 @@ mod tests {
         let list = fetch_pokemon_list(&client).await.expect("list fetch");
         assert!(list.len() > 1000, "got {} entries", list.len());
 
-        let (detail, tree, sprite) = fetch_pokemon_bundle(&client, "eevee")
+        let (detail, tree, sprite) = fetch_pokemon_bundle(&client, "eevee", SpriteVariant::Normal)
             .await
             .expect("bundle fetch");
         assert_eq!(detail.name, "eevee");
         assert!(detail.types.contains(&"normal".to_string()));
         assert!(sprite.is_some(), "eevee should have artwork");
+        assert!(
+            detail.shiny_sprite_url.is_some(),
+            "eevee should have shiny artwork"
+        );
         assert!(
             tree.leaf_count() >= 8,
             "eevee branches {} ways",
@@ -677,7 +689,8 @@ mod tests {
         // A name that does not exist must fail fast rather than burn the full
         // retry budget on an answer that will not change.
         let started = std::time::Instant::now();
-        let missing = fetch_pokemon_bundle(&client, "missingno-not-a-species").await;
+        let missing =
+            fetch_pokemon_bundle(&client, "missingno-not-a-species", SpriteVariant::Normal).await;
         assert!(missing.is_err(), "a bogus species should not resolve");
         assert!(
             started.elapsed() < REQUEST_TIMEOUT,

--- a/src/app.rs
+++ b/src/app.rs
@@ -17,7 +17,9 @@ use tokio::sync::mpsc;
 use crate::api;
 use crate::cache;
 use crate::i18n::Language;
-use crate::models::{AbilityInfo, EvolutionTree, PokemonDetail, PokemonEntry, Sprite};
+use crate::models::{
+    AbilityInfo, EvolutionTree, PokemonDetail, PokemonEntry, Sprite, SpriteVariant,
+};
 use crate::query::Query;
 use crate::team;
 
@@ -35,10 +37,14 @@ pub enum Message {
         evolution: EvolutionTree,
         /// Decoded artwork, if the species had a sprite we could fetch.
         sprite: Option<Sprite>,
+        /// Which palette `sprite` was fetched in. Carried along because the
+        /// shiny toggle can flip while the request is in flight.
+        variant: SpriteVariant,
     },
     /// A standalone sprite (for an evolution-chain member) finished loading.
     SpriteLoaded {
         name: String,
+        variant: SpriteVariant,
         sprite: Option<Sprite>,
     },
     /// An ability's localized text finished loading.
@@ -113,11 +119,16 @@ pub struct App {
     /// In-memory cache so each Pokemon is fetched at most once per session.
     pub details: HashMap<String, PokemonDetail>,
     pub evolutions: HashMap<String, EvolutionTree>,
-    /// Decoded sprites, keyed by Pokemon name. Absent if a species has no art.
-    pub sprites: HashMap<String, Sprite>,
-    /// Names whose sprite is being fetched on demand for the evolution panel,
-    /// so we never queue the same request twice.
-    pub sprite_loading: HashSet<String>,
+    /// Decoded sprites, keyed by palette and then by Pokemon name. Absent if a
+    /// species has no art, or if that palette has not been asked for yet.
+    pub sprites: HashMap<SpriteVariant, HashMap<String, Sprite>>,
+    /// Names whose sprite is being fetched on demand, per palette, so we never
+    /// queue the same request twice.
+    pub sprite_loading: HashMap<SpriteVariant, HashSet<String>>,
+    /// Which palette every sprite on screen is shown in. App-wide rather than
+    /// per-species: moving through the list keeps showing shinies until the
+    /// toggle is switched off again.
+    pub sprite_variant: SpriteVariant,
     /// Cursor into the evolution chain (depth-first order) while the evolution
     /// panel is focused.
     pub evo_cursor: usize,
@@ -180,7 +191,8 @@ impl App {
             details: HashMap::new(),
             evolutions: HashMap::new(),
             sprites: HashMap::new(),
-            sprite_loading: HashSet::new(),
+            sprite_loading: HashMap::new(),
+            sprite_variant: SpriteVariant::Normal,
             evo_cursor: 0,
             language_picker: false,
             lang_cursor: 0,
@@ -320,15 +332,16 @@ impl App {
         // their way (they may not have been requested yet).
         if self.details.contains_key(&name) {
             self.loading_detail = None;
-            self.ensure_chain_sprites();
+            self.ensure_visible_sprites();
             return;
         }
 
         self.loading_detail = Some(name.clone());
         let tx = self.tx.clone();
         let client = self.client.clone();
+        let variant = self.sprite_variant;
         tokio::spawn(async move {
-            let _ = tx.send(resolve_bundle(&client, &name).await).await;
+            let _ = tx.send(resolve_bundle(&client, &name, variant).await).await;
         });
     }
 
@@ -400,24 +413,83 @@ impl App {
         names
     }
 
-    /// Kicks off sprite fetches for every member of the current chain that isn't
-    /// already cached or in flight, so the evolution panel can show its artwork.
-    fn ensure_chain_sprites(&mut self) {
-        for name in self.chain_names() {
-            if self.sprites.contains_key(&name) || self.sprite_loading.contains(&name) {
+    /// Kicks off sprite fetches for everything on screen — the selected species
+    /// and every member of its chain — that isn't already cached or in flight.
+    ///
+    /// Only the palette currently on display is ever requested, so flipping the
+    /// shiny toggle costs the artwork in front of you rather than pre-fetching
+    /// two full sets. The selection is listed separately from the chain because
+    /// an alternate form (`raichu-alola`) does not appear in it under its own
+    /// name — the chain carries the base species.
+    fn ensure_visible_sprites(&mut self) {
+        let variant = self.sprite_variant;
+        let names: Vec<String> = self
+            .selected_name
+            .iter()
+            .cloned()
+            .chain(self.chain_names())
+            .collect();
+
+        for name in names {
+            if self.sprite_for(&name).is_some() || self.sprite_is_loading(&name) {
                 continue;
             }
-            self.sprite_loading.insert(name.clone());
+            // A species whose record is already loaded carries both artwork
+            // URLs, which saves the resolver a `/pokemon` request. `Some(None)`
+            // means we know it has no art at all.
+            let known_url = self
+                .details
+                .get(&name)
+                .map(|detail| detail.sprite_url_for(variant).map(str::to_string));
+
+            self.sprite_loading
+                .entry(variant)
+                .or_default()
+                .insert(name.clone());
             let tx = self.tx.clone();
             let client = self.client.clone();
             tokio::spawn(async move {
-                // A failed chain sprite is non-fatal: `resolve_named_sprite`
-                // reports no art, so the panel shows a placeholder instead of
-                // an error banner.
-                let sprite = resolve_named_sprite(&client, &name).await;
-                let _ = tx.send(Message::SpriteLoaded { name, sprite }).await;
+                // A failed sprite is non-fatal: the resolvers report no art, so
+                // the panel shows a placeholder instead of an error banner.
+                let sprite = match known_url {
+                    Some(url) => resolve_sprite(&client, &name, url.as_deref(), variant).await,
+                    None => resolve_named_sprite(&client, &name, variant).await,
+                };
+                let _ = tx
+                    .send(Message::SpriteLoaded {
+                        name,
+                        variant,
+                        sprite,
+                    })
+                    .await;
             });
         }
+    }
+
+    /// Flips between the normal and shiny palettes, then pulls in whatever
+    /// artwork the new one is missing.
+    fn toggle_shiny(&mut self) {
+        self.sprite_variant = self.sprite_variant.toggled();
+        self.ensure_visible_sprites();
+    }
+
+    /// Decoded artwork for `name` in the palette currently on display.
+    pub fn sprite_for(&self, name: &str) -> Option<&Sprite> {
+        self.sprites.get(&self.sprite_variant)?.get(name)
+    }
+
+    /// Whether `name`'s artwork in the current palette is still in flight.
+    pub fn sprite_is_loading(&self, name: &str) -> bool {
+        self.sprite_loading
+            .get(&self.sprite_variant)
+            .is_some_and(|pending| pending.contains(name))
+    }
+
+    fn remember_sprite(&mut self, name: String, variant: SpriteVariant, sprite: Sprite) {
+        self.sprites
+            .entry(variant)
+            .or_default()
+            .insert(name, sprite);
     }
 
     /// Loads the chain member currently under the evolution cursor — the quick
@@ -457,6 +529,7 @@ impl App {
                 detail,
                 evolution,
                 sprite,
+                variant,
             } => {
                 let name = detail.name.clone();
                 if self.loading_detail.as_deref() == Some(name.as_str()) {
@@ -464,21 +537,29 @@ impl App {
                 }
                 self.evolutions.insert(name.clone(), evolution);
                 if let Some(sprite) = sprite {
-                    self.sprites.insert(name.clone(), sprite);
+                    self.remember_sprite(name.clone(), variant, sprite);
                 }
                 let is_selected = self.selected_name.as_deref() == Some(name.as_str());
                 self.team_loading.remove(&name);
                 self.details.insert(name, detail);
                 // Now that the chain is known, fetch its members' sprites for
-                // the evolution panel.
+                // the evolution panel. This also covers a toggle that happened
+                // while the bundle was in flight: the palette it arrived in may
+                // no longer be the one on screen.
                 if is_selected {
-                    self.ensure_chain_sprites();
+                    self.ensure_visible_sprites();
                 }
             }
-            Message::SpriteLoaded { name, sprite } => {
-                self.sprite_loading.remove(&name);
+            Message::SpriteLoaded {
+                name,
+                variant,
+                sprite,
+            } => {
+                if let Some(pending) = self.sprite_loading.get_mut(&variant) {
+                    pending.remove(&name);
+                }
                 if let Some(sprite) = sprite {
-                    self.sprites.insert(name, sprite);
+                    self.remember_sprite(name, variant, sprite);
                 }
             }
             Message::AbilityLoaded(info) => {
@@ -593,8 +674,9 @@ impl App {
         self.team_loading.insert(name.clone());
         let tx = self.tx.clone();
         let client = self.client.clone();
+        let variant = self.sprite_variant;
         tokio::spawn(async move {
-            let _ = tx.send(resolve_bundle(&client, &name).await).await;
+            let _ = tx.send(resolve_bundle(&client, &name, variant).await).await;
         });
     }
 
@@ -703,6 +785,7 @@ impl App {
             KeyCode::Char(' ') => self.toggle_team_membership(),
             KeyCode::Char('p') | KeyCode::Char('P') => self.team_card = true,
             KeyCode::Char('a') | KeyCode::Char('A') => self.open_abilities(),
+            KeyCode::Char('x') | KeyCode::Char('X') => self.toggle_shiny(),
             KeyCode::Char('?') => self.help_card = true,
             _ => {}
         }
@@ -740,6 +823,7 @@ impl App {
             }
             KeyCode::Enter => self.jump_to_evolution_member(),
             KeyCode::Char('t') | KeyCode::Char('T') => self.open_matchups(),
+            KeyCode::Char('x') | KeyCode::Char('X') => self.toggle_shiny(),
             KeyCode::Char('?') => self.help_card = true,
             _ => {}
         }
@@ -874,10 +958,10 @@ impl App {
         self.evolutions.get(name)
     }
 
-    /// Decoded sprite for the selected Pokemon, if one was loaded.
+    /// Decoded sprite for the selected Pokemon in the current palette, if one
+    /// was loaded.
     pub fn selected_sprite(&self) -> Option<&Sprite> {
-        let name = self.selected_name.as_ref()?;
-        self.sprites.get(name)
+        self.sprite_for(self.selected_name.as_deref()?)
     }
 
     /// True while the detail panel is awaiting its current selection.
@@ -896,23 +980,26 @@ impl App {
 
 /// Resolves a species from the cache, falling back to the network and storing
 /// whatever it had to fetch.
-async fn resolve_bundle(client: &reqwest::Client, name: &str) -> Message {
+async fn resolve_bundle(client: &reqwest::Client, name: &str, variant: SpriteVariant) -> Message {
     if let Some(bundle) = cache::load_bundle(name).await {
-        let sprite = resolve_sprite(client, name, bundle.detail.sprite_url.as_deref()).await;
+        let sprite =
+            resolve_sprite(client, name, bundle.detail.sprite_url_for(variant), variant).await;
         return Message::PokemonLoaded {
             detail: bundle.detail,
             evolution: bundle.evolution,
             sprite,
+            variant,
         };
     }
-    match api::fetch_pokemon_bundle(client, name).await {
+    match api::fetch_pokemon_bundle(client, name, variant).await {
         Ok((detail, evolution, sprite)) => {
             cache::store_bundle(name, &detail, &evolution).await;
-            record_sprite(name, sprite.as_ref()).await;
+            record_sprite(name, sprite.as_ref(), variant).await;
             Message::PokemonLoaded {
                 detail,
                 evolution,
                 sprite,
+                variant,
             }
         }
         Err(err) => Message::Error(err.to_string()),
@@ -920,31 +1007,48 @@ async fn resolve_bundle(client: &reqwest::Client, name: &str) -> Message {
 }
 
 /// Cache-first sprite lookup for a species whose artwork URL we already know
-/// (because its details came out of the cache alongside it).
-async fn resolve_sprite(client: &reqwest::Client, name: &str, url: Option<&str>) -> Option<Sprite> {
-    if let Some(sprite) = cache::load_sprite(name).await {
+/// (because its details came out of the cache alongside it). `url` is the one
+/// for `variant`, so a species with no shiny art resolves its normal sprite —
+/// stored under the shiny name, since that is the question we asked.
+async fn resolve_sprite(
+    client: &reqwest::Client,
+    name: &str,
+    url: Option<&str>,
+    variant: SpriteVariant,
+) -> Option<Sprite> {
+    if let Some(sprite) = cache::load_sprite(name, variant).await {
         return Some(sprite);
     }
-    if cache::has_sprite_answer(name).await {
+    if cache::has_sprite_answer(name, variant).await {
         return None; // asked before: this species genuinely has no artwork
     }
-    let sprite = api::fetch_sprite(client, url?).await.ok();
-    record_sprite(name, sprite.as_ref()).await;
+    let Some(url) = url else {
+        // The record itself says there is no artwork in either palette. Write
+        // that down so the question is not re-asked on every toggle.
+        record_sprite(name, None, variant).await;
+        return None;
+    };
+    let sprite = api::fetch_sprite(client, url).await.ok();
+    record_sprite(name, sprite.as_ref(), variant).await;
     sprite
 }
 
 /// Cache-first sprite lookup for a chain member we know nothing else about.
 /// Only the network path has to resolve the artwork URL first.
-async fn resolve_named_sprite(client: &reqwest::Client, name: &str) -> Option<Sprite> {
-    if let Some(sprite) = cache::load_sprite(name).await {
+async fn resolve_named_sprite(
+    client: &reqwest::Client,
+    name: &str,
+    variant: SpriteVariant,
+) -> Option<Sprite> {
+    if let Some(sprite) = cache::load_sprite(name, variant).await {
         return Some(sprite);
     }
-    if cache::has_sprite_answer(name).await {
+    if cache::has_sprite_answer(name, variant).await {
         return None;
     }
-    match api::fetch_named_sprite(client, name).await {
+    match api::fetch_named_sprite(client, name, variant).await {
         Ok(sprite) => {
-            record_sprite(name, sprite.as_ref()).await;
+            record_sprite(name, sprite.as_ref(), variant).await;
             sprite
         }
         // A transient failure must not be written down as "no artwork", or the
@@ -982,10 +1086,11 @@ async fn resolve_type_members(client: &reqwest::Client, type_name: &str) -> Vec<
 }
 
 /// Stores a freshly fetched sprite, or the fact that there wasn't one, so the
-/// next run does not repeat the request either way.
-async fn record_sprite(name: &str, sprite: Option<&Sprite>) {
+/// next run does not repeat the request either way. Recorded per palette: a
+/// species can be cached shiny and unknown normal, or the other way round.
+async fn record_sprite(name: &str, sprite: Option<&Sprite>, variant: SpriteVariant) {
     match sprite {
-        Some(sprite) => cache::store_sprite(name, sprite).await,
-        None => cache::store_missing_sprite(name).await,
+        Some(sprite) => cache::store_sprite(name, sprite, variant).await,
+        None => cache::store_missing_sprite(name, variant).await,
     }
 }

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -17,12 +17,14 @@ use std::time::{Duration, SystemTime};
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 
-use crate::models::{AbilityInfo, EvolutionTree, PokemonDetail, PokemonEntry, Sprite};
+use crate::models::{
+    AbilityInfo, EvolutionTree, PokemonDetail, PokemonEntry, Sprite, SpriteVariant,
+};
 
 /// Bumped whenever the cached representation changes shape. Files written by
 /// an older build are treated as misses and overwritten on the next fetch,
 /// which saves us from ever deserializing stale data into the wrong struct.
-const VERSION: u32 = 3;
+const VERSION: u32 = 4;
 
 /// How long the master species list stays fresh. Individual records never
 /// expire — PokeAPI does not rewrite history, it only appends new species, and
@@ -122,13 +124,13 @@ pub async fn store_type_members(type_name: &str, members: &[String]) {
     write_json(&path, &members.to_vec()).await;
 }
 
-/// A decoded sprite, if one has ever been cached for `name`.
+/// A decoded sprite, if one has ever been cached for `name` in `variant`.
 ///
 /// Sprites are stored re-encoded as PNG rather than as raw RGBA: a species'
 /// artwork is a few kilobytes compressed against ~36 KB flattened, and the
 /// decoder is already a dependency.
-pub async fn load_sprite(name: &str) -> Option<Sprite> {
-    let path = sprite_path(name)?;
+pub async fn load_sprite(name: &str, variant: SpriteVariant) -> Option<Sprite> {
+    let path = sprite_path(name, variant)?;
     let bytes = tokio::fs::read(&path).await.ok()?;
     let image = image::load_from_memory(&bytes).ok()?.to_rgba8();
     let (width, height) = image.dimensions();
@@ -139,8 +141,8 @@ pub async fn load_sprite(name: &str) -> Option<Sprite> {
     })
 }
 
-pub async fn store_sprite(name: &str, sprite: &Sprite) {
-    let Some(path) = sprite_path(name) else {
+pub async fn store_sprite(name: &str, sprite: &Sprite, variant: SpriteVariant) {
+    let Some(path) = sprite_path(name, variant) else {
         return;
     };
     let Some(bytes) = encode_png(sprite) else {
@@ -149,20 +151,22 @@ pub async fn store_sprite(name: &str, sprite: &Sprite) {
     write_atomic(&path, &bytes).await;
 }
 
-/// Records that `name` has no artwork at all, so we do not re-ask the network
-/// on every run. Stored as an empty file, which [`load_sprite`] fails to decode
-/// and therefore reports as "no sprite" — the same answer, without the request.
-pub async fn store_missing_sprite(name: &str) {
-    let Some(path) = sprite_path(name) else {
+/// Records that `name` has no artwork in `variant`, so we do not re-ask the
+/// network on every run. Stored as an empty file, which [`load_sprite`] fails to
+/// decode and therefore reports as "no sprite" — the same answer, without the
+/// request.
+pub async fn store_missing_sprite(name: &str, variant: SpriteVariant) {
+    let Some(path) = sprite_path(name, variant) else {
         return;
     };
     write_atomic(&path, &[]).await;
 }
 
-/// Whether we have already resolved `name`'s artwork one way or the other.
-/// Distinguishes "never looked" from "looked, and there is none".
-pub async fn has_sprite_answer(name: &str) -> bool {
-    match sprite_path(name) {
+/// Whether we have already resolved `name`'s artwork in `variant` one way or
+/// the other. Distinguishes "never looked" from "looked, and there is none",
+/// per palette: a species can be cached in one and unknown in the other.
+pub async fn has_sprite_answer(name: &str, variant: SpriteVariant) -> bool {
+    match sprite_path(name, variant) {
         Some(path) => tokio::fs::metadata(&path).await.is_ok(),
         None => false,
     }
@@ -218,8 +222,14 @@ fn type_path(type_name: &str) -> Option<PathBuf> {
     )
 }
 
-fn sprite_path(name: &str) -> Option<PathBuf> {
-    Some(root()?.join("sprites").join(format!("{}.png", slug(name))))
+fn sprite_path(name: &str, variant: SpriteVariant) -> Option<PathBuf> {
+    Some(root()?.join("sprites").join(sprite_file(name, variant)))
+}
+
+/// Filename one species' artwork is stored under. The palette is part of the
+/// name, or a shiny PNG would silently overwrite the normal one.
+fn sprite_file(name: &str, variant: SpriteVariant) -> String {
+    format!("{}{}.png", slug(name), variant.file_suffix())
 }
 
 fn translation_path(name: &str, lang: &str) -> Option<PathBuf> {
@@ -317,6 +327,15 @@ mod tests {
     fn slug_neutralises_path_separators() {
         assert_eq!(slug("../../etc/passwd"), "______etc_passwd");
         assert!(!slug("a/b").contains('/'));
+    }
+
+    #[test]
+    fn shiny_artwork_gets_its_own_filename() {
+        assert_eq!(sprite_file("pikachu", SpriteVariant::Normal), "pikachu.png");
+        assert_eq!(
+            sprite_file("pikachu", SpriteVariant::Shiny),
+            "pikachu.shiny.png"
+        );
     }
 
     #[test]

--- a/src/i18n.rs
+++ b/src/i18n.rs
@@ -188,6 +188,8 @@ pub struct Strings {
     pub legendary_label: &'static str,
     pub mythical_label: &'static str,
     pub baby_label: &'static str,
+    /// Badge marking the info card while shiny artwork is on display.
+    pub shiny_label: &'static str,
 }
 
 /// Labels for the help overlay.
@@ -209,6 +211,7 @@ pub struct HelpStrings {
     pub act_evolutions: &'static str,
     pub act_types: &'static str,
     pub act_abilities: &'static str,
+    pub act_shiny: &'static str,
     pub act_party_toggle: &'static str,
     pub act_party_card: &'static str,
     pub act_sort: &'static str,
@@ -422,6 +425,7 @@ impl Strings {
                 act_evolutions: "Evolutions",
                 act_types: "Type matchups",
                 act_abilities: "Abilities",
+                act_shiny: "Shiny artwork",
                 act_party_toggle: "Add / remove from party",
                 act_party_card: "Party",
                 act_sort: "Sort order",
@@ -464,6 +468,7 @@ impl Strings {
             legendary_label: "Legendary",
             mythical_label: "Mythical",
             baby_label: "Baby",
+            shiny_label: "Shiny",
         }
     }
 
@@ -530,6 +535,7 @@ impl Strings {
                 act_evolutions: "Evrimler",
                 act_types: "Tip eşleşmeleri",
                 act_abilities: "Yetenekler",
+                act_shiny: "Parlak görsel",
                 act_party_toggle: "Takıma ekle / çıkar",
                 act_party_card: "Takım",
                 act_sort: "Sıralama",
@@ -572,6 +578,7 @@ impl Strings {
             legendary_label: "Efsanevi",
             mythical_label: "Mitik",
             baby_label: "Yavru",
+            shiny_label: "Parlak",
         }
     }
 
@@ -638,6 +645,7 @@ impl Strings {
                 act_evolutions: "Entwicklungen",
                 act_types: "Typ-Matchups",
                 act_abilities: "Fähigkeiten",
+                act_shiny: "Schillernde Grafik",
                 act_party_toggle: "Team hinzu / entfernen",
                 act_party_card: "Team",
                 act_sort: "Sortierung",
@@ -680,6 +688,7 @@ impl Strings {
             legendary_label: "Legendär",
             mythical_label: "Mysteriös",
             baby_label: "Baby",
+            shiny_label: "Schillernd",
         }
     }
 
@@ -746,6 +755,7 @@ impl Strings {
                 act_evolutions: "Évolutions",
                 act_types: "Affinités de type",
                 act_abilities: "Talents",
+                act_shiny: "Illustration chromatique",
                 act_party_toggle: "Ajouter / retirer de l'équipe",
                 act_party_card: "Équipe",
                 act_sort: "Tri",
@@ -788,6 +798,7 @@ impl Strings {
             legendary_label: "Légendaire",
             mythical_label: "Fabuleux",
             baby_label: "Bébé",
+            shiny_label: "Chromatique",
         }
     }
 
@@ -854,6 +865,7 @@ impl Strings {
                 act_evolutions: "Evoluciones",
                 act_types: "Efectividad de tipos",
                 act_abilities: "Habilidades",
+                act_shiny: "Ilustración variocolor",
                 act_party_toggle: "Añadir / quitar del equipo",
                 act_party_card: "Equipo",
                 act_sort: "Orden",
@@ -896,6 +908,7 @@ impl Strings {
             legendary_label: "Legendario",
             mythical_label: "Singular",
             baby_label: "Bebé",
+            shiny_label: "Variocolor",
         }
     }
 
@@ -962,6 +975,7 @@ impl Strings {
                 act_evolutions: "Evoluzioni",
                 act_types: "Efficacia dei tipi",
                 act_abilities: "Abilità",
+                act_shiny: "Illustrazione cromatica",
                 act_party_toggle: "Aggiungi / togli dalla squadra",
                 act_party_card: "Squadra",
                 act_sort: "Ordinamento",
@@ -1004,6 +1018,7 @@ impl Strings {
             legendary_label: "Leggendario",
             mythical_label: "Misterioso",
             baby_label: "Cucciolo",
+            shiny_label: "Cromatico",
         }
     }
 }

--- a/src/models.rs
+++ b/src/models.rs
@@ -141,6 +141,42 @@ impl AbilityInfo {
     }
 }
 
+/// Which palette of a species' front artwork to show.
+///
+/// This is app-wide state rather than a property of a species: the shiny toggle
+/// stays on while the user moves through the list, so a whole evolution chain
+/// can be inspected in its shiny colours.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash)]
+pub enum SpriteVariant {
+    #[default]
+    Normal,
+    Shiny,
+}
+
+impl SpriteVariant {
+    /// The other palette, for the toggle key.
+    pub fn toggled(self) -> Self {
+        match self {
+            Self::Normal => Self::Shiny,
+            Self::Shiny => Self::Normal,
+        }
+    }
+
+    pub fn is_shiny(self) -> bool {
+        matches!(self, Self::Shiny)
+    }
+
+    /// Filename infix that keeps a shiny PNG from overwriting the normal one in
+    /// the on-disk cache. Empty for [`Normal`](Self::Normal), so sprites cached
+    /// before shinies existed stay valid.
+    pub fn file_suffix(self) -> &'static str {
+        match self {
+            Self::Normal => "",
+            Self::Shiny => ".shiny",
+        }
+    }
+}
+
 /// Fully resolved details for one Pokemon, ready to render.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PokemonDetail {
@@ -167,6 +203,9 @@ pub struct PokemonDetail {
     pub weight: u32,
     /// URL of the front-facing PNG artwork, if the species has one.
     pub sprite_url: Option<String>,
+    /// URL of the same artwork in the shiny palette. Absent for the handful of
+    /// species PokeAPI ships no shiny sprite for.
+    pub shiny_sprite_url: Option<String>,
     /// Pokedex genus (e.g. `"Seed Pokémon"`) keyed by PokeAPI language code.
     pub genera: HashMap<String, String>,
     /// Pokedex flavor-text blurbs, cleaned of control characters, keyed by
@@ -178,6 +217,18 @@ impl PokemonDetail {
     /// Sum of all base stats — a common "power level" heuristic.
     pub fn stat_total(&self) -> u32 {
         self.stats.iter().map(|s| s.base as u32).sum()
+    }
+
+    /// Artwork URL in the requested palette, falling back to the normal one for
+    /// a species with no shiny art — a familiar sprite beats an empty card.
+    pub fn sprite_url_for(&self, variant: SpriteVariant) -> Option<&str> {
+        match variant {
+            SpriteVariant::Normal => self.sprite_url.as_deref(),
+            SpriteVariant::Shiny => self
+                .shiny_sprite_url
+                .as_deref()
+                .or(self.sprite_url.as_deref()),
+        }
     }
 
     /// Genus in the requested language, falling back to English when that
@@ -425,6 +476,47 @@ mod tests {
         ] {
             assert_eq!(entry(id).generation(), Some(gen), "dex #{id}");
         }
+    }
+
+    fn detail_with_sprites(normal: Option<&str>, shiny: Option<&str>) -> PokemonDetail {
+        PokemonDetail {
+            name: "pikachu".into(),
+            species: "pikachu".into(),
+            dex_number: 25,
+            is_legendary: false,
+            is_mythical: false,
+            is_baby: false,
+            types: Vec::new(),
+            abilities: Vec::new(),
+            stats: Vec::new(),
+            height: 0,
+            weight: 0,
+            sprite_url: normal.map(str::to_string),
+            shiny_sprite_url: shiny.map(str::to_string),
+            genera: HashMap::new(),
+            flavors: HashMap::new(),
+        }
+    }
+
+    #[test]
+    fn shiny_artwork_falls_back_to_the_normal_palette() {
+        let both = detail_with_sprites(Some("front.png"), Some("shiny.png"));
+        assert_eq!(both.sprite_url_for(SpriteVariant::Shiny), Some("shiny.png"));
+        assert_eq!(
+            both.sprite_url_for(SpriteVariant::Normal),
+            Some("front.png")
+        );
+
+        // No shiny art: show the normal sprite rather than an empty card.
+        let normal_only = detail_with_sprites(Some("front.png"), None);
+        assert_eq!(
+            normal_only.sprite_url_for(SpriteVariant::Shiny),
+            Some("front.png")
+        );
+
+        // No art at all stays "no art" in either palette.
+        let neither = detail_with_sprites(None, None);
+        assert_eq!(neither.sprite_url_for(SpriteVariant::Shiny), None);
     }
 
     #[test]

--- a/src/team.rs
+++ b/src/team.rs
@@ -202,6 +202,7 @@ mod tests {
             height: 0,
             weight: 0,
             sprite_url: None,
+            shiny_sprite_url: None,
             genera: HashMap::new(),
             flavors: HashMap::new(),
         }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -225,7 +225,7 @@ fn render_details(frame: &mut Frame, app: &App, s: &Strings, area: Rect) {
 
     let mut lines: Vec<Line> = Vec::new();
 
-    lines.push(Line::from(vec![
+    let mut title_spans = vec![
         Span::styled(
             title_case(&detail.name),
             Style::default()
@@ -236,7 +236,18 @@ fn render_details(frame: &mut Frame, app: &App, s: &Strings, area: Rect) {
             format!("   #{:04}", detail.dex_number),
             Style::default().fg(theme::OVERLAY),
         ),
-    ]));
+    ];
+    // Say so when the artwork is shiny: an unfamiliar palette otherwise reads
+    // as a rendering bug rather than a deliberate choice.
+    if app.sprite_variant.is_shiny() {
+        title_spans.push(Span::styled(
+            format!("  ✦ {}", s.shiny_label),
+            Style::default()
+                .fg(theme::YELLOW)
+                .add_modifier(Modifier::BOLD),
+        ));
+    }
+    lines.push(Line::from(title_spans));
 
     // Pokedex genus, e.g. "Seed Pokémon" — the headline of the info card, in the
     // active language where PokeAPI has it.
@@ -510,7 +521,14 @@ fn pixel_color(rgba: [u8; 4]) -> Color {
 
 fn render_evolution(frame: &mut Frame, app: &App, s: &Strings, area: Rect) {
     let focused = app.focus == Focus::Evolution;
-    let block = panel_block(s.evolution_title, focused);
+    let block = if app.sprite_variant.is_shiny() {
+        panel_block_owned(
+            format!("{}✦ {} ", s.evolution_title, s.shiny_label),
+            focused,
+        )
+    } else {
+        panel_block(s.evolution_title, focused)
+    };
     let inner = block.inner(area);
     frame.render_widget(block, area);
 
@@ -925,10 +943,10 @@ fn draw_card(
         width: w,
         height: h.saturating_sub(text_rows),
     };
-    match app.sprites.get(&node.name) {
+    match app.sprite_for(&node.name) {
         Some(sprite) => render_sprite_capped(frame, sprite_area, sprite, w),
         None => {
-            let placeholder = if app.sprite_loading.contains(&node.name) {
+            let placeholder = if app.sprite_is_loading(&node.name) {
                 s.sprite_loading
             } else {
                 "…"
@@ -1235,6 +1253,7 @@ fn render_help(frame: &mut Frame, s: &Strings, full: Rect) {
         ("E", h.act_evolutions),
         ("T", h.act_types),
         ("A", h.act_abilities),
+        ("X", h.act_shiny),
         ("Space", h.act_party_toggle),
         ("P", h.act_party_card),
         ("S", h.act_sort),
@@ -1252,6 +1271,7 @@ fn render_help(frame: &mut Frame, s: &Strings, full: Rect) {
         ("", h.ctx_evolution),
         ("← → ↑ ↓ · h j k l", h.act_chain_move),
         ("Enter", h.act_chain_jump),
+        ("X", h.act_shiny),
         ("Esc · Tab", h.act_back),
         ("", ""),
         ("", h.ctx_cards),


### PR DESCRIPTION
Closes #10.

`X` in the list and in the evolution panel flips every sprite on screen — the info panel and each card in the chain — into its shiny palette, so a whole line can be inspected in its shiny colours. The toggle is app-wide rather than per-species: it stays on while moving through the list. The info panel carries a `✦ Shiny` badge and the evolution panel's title says so too, since an unfamiliar palette otherwise reads as a rendering bug.

### What changed

- **`api.rs`** — `RawSprites` parses `front_shiny`; `fetch_pokemon_bundle` and `fetch_named_sprite` take the palette to fetch.
- **`models.rs`** — new `SpriteVariant`, plus `PokemonDetail::shiny_sprite_url` and `sprite_url_for(variant)`, which falls back to the normal URL for a species with no shiny art so the toggle never leaves an empty card.
- **`cache.rs`** — the palette is part of the sprite filename (`{slug}.shiny.png`), and `has_sprite_answer` / `store_missing_sprite` make the same distinction, so a species can be resolved in one palette and unknown in the other. The normal filename is unchanged, so sprites cached by earlier builds stay valid.
- **`app.rs`** — the sprite maps are nested by palette; `ensure_visible_sprites` replaces `ensure_chain_sprites` and covers the selection as well as the chain, because an alternate form (`raichu-alola`) does not appear in its own chain under that name.
- **`ui.rs` / `i18n.rs`** — the badge, the help-overlay row, and the new action translated into all six languages using each one's official term.

### Fetching

Only the palette on screen is ever requested: flipping the toggle pulls in what the new palette is missing instead of pre-fetching two full sets, and where the species record is already loaded the artwork URL is read out of it rather than costing another `/pokemon` request.

### Note on the cache version

`VERSION` goes 3 → 4 because `PokemonDetail` gained a field — bundles written by an older build would otherwise fail to deserialize. Existing installs re-fetch species records once on first run; cached sprites, abilities, type rosters and translations are unaffected.

### Out of scope

Shiny female forms, back sprites and the generation-specific sprite sets, as the issue says. Just `front_shiny`.

### Verification

- `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` clean; 59 tests pass, plus the ignored live-API test (confirms `front_shiny` comes back for Eevee).
- New tests cover the shiny→normal URL fallback and the per-palette sprite filename.
- Driven in a pty against the real app: the badge appears on `X` and clears on a second press, the help overlay lists the binding, and the Bulbasaur line's three shiny PNGs land in the cache on demand without touching the normal ones.