### PR TITLE
Fix blank evolution artwork for form-named species, and expire the no-artwork marker

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -45,6 +45,13 @@ pub enum ApiError {
     Network(#[from] reqwest::Error),
     #[error("could not locate the evolution chain for this Pokemon")]
     MissingEvolutionChain,
+    /// The server answered 404. Unlike the transport failures [`Network`]
+    /// covers, this is a permanent answer about a name, so callers can write it
+    /// down instead of re-asking on every run.
+    ///
+    /// [`Network`]: ApiError::Network
+    #[error("no such resource: {0}")]
+    NotFound(String),
     #[error("could not decode sprite image: {0}")]
     Image(#[from] image::ImageError),
 }
@@ -67,6 +74,22 @@ pub fn build_client() -> Result<reqwest::Client, ApiError> {
 fn request_permits() -> &'static Semaphore {
     static PERMITS: OnceLock<Semaphore> = OnceLock::new();
     PERMITS.get_or_init(|| Semaphore::new(MAX_CONCURRENT_REQUESTS))
+}
+
+/// Wraps a failed request in the error the caller sees.
+///
+/// A 404 is separated out because it is the one failure that says something
+/// durable about the *name* rather than about the connection: callers may cache
+/// it, which they must never do for a timeout.
+fn api_error(err: reqwest::Error) -> ApiError {
+    if err.status() == Some(reqwest::StatusCode::NOT_FOUND) {
+        let what = err
+            .url()
+            .map(|u| u.path().trim_start_matches("/api/v2/").to_string())
+            .unwrap_or_else(|| "resource".to_string());
+        return ApiError::NotFound(what);
+    }
+    ApiError::Network(err)
 }
 
 /// Sorts a `reqwest` failure into the classes the retry policy reasons about.
@@ -121,7 +144,7 @@ where
 
         let last_attempt = attempt + 1 >= retry::MAX_ATTEMPTS;
         if last_attempt || !retry::is_retryable(classify(&err)) {
-            return Err(ApiError::Network(err));
+            return Err(api_error(err));
         }
 
         tokio::time::sleep(retry::backoff_delay(attempt, jitter_fraction())).await;
@@ -279,9 +302,12 @@ pub async fn fetch_ability(client: &reqwest::Client, name: &str) -> Result<Abili
     })
 }
 
-/// Fetches and decodes just the sprite for a named species, in the requested
+/// Fetches and decodes just the sprite for a named Pokemon, in the requested
 /// palette. Used to lazily populate the evolution overlay, where every member
 /// of the chain needs art.
+///
+/// `name` is a `/pokemon` key, i.e. a *variety* name — callers holding a
+/// species name resolve it through [`fetch_default_variety`] first.
 pub async fn fetch_named_sprite(
     client: &reqwest::Client,
     name: &str,
@@ -380,6 +406,34 @@ struct SpeciesInfo {
     is_baby: bool,
     genera: HashMap<String, String>,
     flavors: HashMap<String, String>,
+}
+
+/// Resolves the `/pokemon` key a species' artwork is filed under.
+///
+/// Evolution chains name *species* (`giratina`), but sprites hang off
+/// varieties (`giratina-altered`), and for a species whose default form has its
+/// own name the two differ — `/pokemon/giratina` is a 404. The species record
+/// carries the mapping, so ask it rather than guessing.
+pub async fn fetch_default_variety(
+    client: &reqwest::Client,
+    species: &str,
+) -> Result<String, ApiError> {
+    let url = format!("{BASE_URL}/pokemon-species/{species}");
+    let raw: RawSpecies = get_json(client, &url).await?;
+    Ok(default_variety_name(&raw.varieties, species))
+}
+
+/// Picks the default variety out of a species' form list.
+///
+/// Falling back to the species name covers the ordinary case where the two
+/// names agree, and is the right answer for a payload that marks no default at
+/// all — better a request that may work than none.
+fn default_variety_name(varieties: &[RawVariety], species: &str) -> String {
+    varieties
+        .iter()
+        .find(|v| v.is_default)
+        .map(|v| v.pokemon.name.clone())
+        .unwrap_or_else(|| species.to_string())
 }
 
 /// Fetches a species record, pulling out the evolution-chain URL plus the genus
@@ -578,6 +632,17 @@ struct RawSpecies {
     genera: Vec<RawGenus>,
     #[serde(default)]
     flavor_text_entries: Vec<RawFlavorText>,
+    #[serde(default)]
+    varieties: Vec<RawVariety>,
+}
+
+/// One entry of a species' `varieties` list: the forms it ships as, exactly one
+/// of which is the default.
+#[derive(serde::Deserialize)]
+struct RawVariety {
+    #[serde(default)]
+    is_default: bool,
+    pokemon: NamedResource,
 }
 
 #[derive(serde::Deserialize)]
@@ -686,17 +751,83 @@ mod tests {
             tree.leaf_count()
         );
 
+        // The fact the evolution-card fix rests on: a species whose default
+        // form is named after that form resolves to the form's name, which is
+        // the only one `/pokemon` will answer to.
+        let variety = fetch_default_variety(&client, "giratina")
+            .await
+            .expect("species fetch");
+        assert_eq!(variety, "giratina-altered");
+        assert!(
+            fetch_named_sprite(&client, &variety, SpriteVariant::Normal)
+                .await
+                .expect("sprite fetch")
+                .is_some(),
+            "giratina-altered should have artwork"
+        );
+
         // A name that does not exist must fail fast rather than burn the full
         // retry budget on an answer that will not change.
         let started = std::time::Instant::now();
         let missing =
             fetch_pokemon_bundle(&client, "missingno-not-a-species", SpriteVariant::Normal).await;
-        assert!(missing.is_err(), "a bogus species should not resolve");
+        assert!(
+            matches!(missing, Err(ApiError::NotFound(_))),
+            "a bogus species should read as a 404, not a transport failure"
+        );
         assert!(
             started.elapsed() < REQUEST_TIMEOUT,
             "a 404 took {:?}, so it was retried",
             started.elapsed()
         );
+    }
+
+    /// Parses just the `varieties` list out of a `/pokemon-species` payload,
+    /// which is all `default_variety_name` reads.
+    fn varieties(json: &str) -> Vec<RawVariety> {
+        serde_json::from_str::<RawSpecies>(json)
+            .expect("species payload parses")
+            .varieties
+    }
+
+    #[test]
+    fn a_species_named_after_its_form_resolves_to_the_form() {
+        let raw = varieties(
+            r#"{
+              "id": 487,
+              "evolution_chain": { "url": "" },
+              "varieties": [
+                { "is_default": true,  "pokemon": { "name": "giratina-altered" } },
+                { "is_default": false, "pokemon": { "name": "giratina-origin"  } }
+              ]
+            }"#,
+        );
+        assert_eq!(default_variety_name(&raw, "giratina"), "giratina-altered");
+    }
+
+    #[test]
+    fn an_ordinary_species_resolves_to_its_own_name() {
+        let raw = varieties(
+            r#"{
+              "id": 483,
+              "evolution_chain": { "url": "" },
+              "varieties": [{ "is_default": true, "pokemon": { "name": "dialga" } }]
+            }"#,
+        );
+        assert_eq!(default_variety_name(&raw, "dialga"), "dialga");
+    }
+
+    #[test]
+    fn a_payload_marking_no_default_falls_back_to_the_species_name() {
+        let raw = varieties(
+            r#"{
+              "id": 1,
+              "evolution_chain": { "url": "" },
+              "varieties": [{ "is_default": false, "pokemon": { "name": "odd-form" } }]
+            }"#,
+        );
+        assert_eq!(default_variety_name(&raw, "bulbasaur"), "bulbasaur");
+        assert_eq!(default_variety_name(&[], "bulbasaur"), "bulbasaur");
     }
 
     /// A trimmed `/evolution-chain` payload in the exact shape PokeAPI sends:

--- a/src/app.rs
+++ b/src/app.rs
@@ -15,6 +15,7 @@ use ratatui::DefaultTerminal;
 use tokio::sync::mpsc;
 
 use crate::api;
+use crate::api::ApiError;
 use crate::cache;
 use crate::i18n::Language;
 use crate::models::{
@@ -1046,15 +1047,52 @@ async fn resolve_named_sprite(
     if cache::has_sprite_answer(name, variant).await {
         return None;
     }
-    match api::fetch_named_sprite(client, name, variant).await {
+    // Chain members arrive as species names, which are not always valid
+    // `/pokemon` keys — see `resolve_default_variety`. The answer is cached
+    // under the species name either way, since that is what the UI asks for.
+    let variety = resolve_default_variety(client, name).await?;
+
+    match api::fetch_named_sprite(client, &variety, variant).await {
         Ok(sprite) => {
             record_sprite(name, sprite.as_ref(), variant).await;
             sprite
+        }
+        // A 404 is a permanent answer about the name, so it is worth writing
+        // down rather than re-asking on every run.
+        Err(ApiError::NotFound(_)) => {
+            record_sprite(name, None, variant).await;
+            None
         }
         // A transient failure must not be written down as "no artwork", or the
         // species would stay blank for as long as the cache lives.
         Err(_) => None,
     }
+}
+
+/// The `/pokemon` key a species' artwork is filed under, cache first.
+///
+/// Most of the time this is the species name itself, but a species whose
+/// default form has its own name (`giratina` -> `giratina-altered`) has no
+/// `/pokemon` entry under the bare name at all, and its card would otherwise
+/// stay blank forever.
+///
+/// `name` can also arrive already being a variety (`raichu-alola`, straight out
+/// of the master list), which has no species record of its own. That 404 means
+/// "the name is its own key" — cached like any other answer, so the failing
+/// request happens once per install rather than once per view.
+async fn resolve_default_variety(client: &reqwest::Client, name: &str) -> Option<String> {
+    if let Some(variety) = cache::load_default_variety(name).await {
+        return Some(variety);
+    }
+    let variety = match api::fetch_default_variety(client, name).await {
+        Ok(variety) => variety,
+        Err(ApiError::NotFound(_)) => name.to_string(),
+        // Nothing was learned, so nothing is written down; the next run asks
+        // again rather than filing a network hiccup as a fact.
+        Err(_) => return None,
+    };
+    cache::store_default_variety(name, &variety).await;
+    Some(variety)
 }
 
 /// Resolves one ability's localized text, cache first.

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -31,6 +31,16 @@ const VERSION: u32 = 4;
 /// those show up when the list is refreshed.
 const LIST_TTL: Duration = Duration::from_secs(30 * 24 * 60 * 60);
 
+/// How long a recorded "this species has no artwork" answer is trusted.
+///
+/// The reasoning that makes every other record permanent — PokeAPI appends, it
+/// does not rewrite — does not hold for artwork: sprites get backfilled for
+/// newly added species, and those are exactly the ones likely to be missing art
+/// the first time anyone looks. Without an expiry that species stays blank on
+/// this install forever, with no way for the user to know why. A successfully
+/// decoded sprite still never expires; only the negative answer does.
+const MISSING_SPRITE_TTL: Duration = Duration::from_secs(7 * 24 * 60 * 60);
+
 /// A cached copy of the master list, plus whether it is still within
 /// [`LIST_TTL`]. A stale list is still returned: it is a far better starting
 /// point than an empty sidebar, and the caller can refresh in the background
@@ -165,11 +175,31 @@ pub async fn store_missing_sprite(name: &str, variant: SpriteVariant) {
 /// Whether we have already resolved `name`'s artwork in `variant` one way or
 /// the other. Distinguishes "never looked" from "looked, and there is none",
 /// per palette: a species can be cached in one and unknown in the other.
+///
+/// A third state sits between them — "looked a while ago, and there was none",
+/// which reads as a miss so the question gets asked again. See
+/// [`MISSING_SPRITE_TTL`].
 pub async fn has_sprite_answer(name: &str, variant: SpriteVariant) -> bool {
     match sprite_path(name, variant) {
-        Some(path) => tokio::fs::metadata(&path).await.is_ok(),
+        Some(path) => sprite_answer_is_current(&path).await,
         None => false,
     }
+}
+
+/// Whether the answer stored at `path` is still one we are willing to reuse.
+///
+/// Split out from [`has_sprite_answer`] so the expiry can be tested against a
+/// real file without going through the process-wide cache root.
+async fn sprite_answer_is_current(path: &Path) -> bool {
+    let Ok(meta) = tokio::fs::metadata(path).await else {
+        return false; // never looked
+    };
+    // A decoded PNG is final. Only the empty marker written by
+    // `store_missing_sprite` is allowed to go stale.
+    if meta.len() > 0 {
+        return true;
+    }
+    age(path).await.is_some_and(|a| a < MISSING_SPRITE_TTL)
 }
 
 /// A machine translation of a flavor blurb. These cost a rate-limited
@@ -343,6 +373,67 @@ mod tests {
         let raw = br#"{"version":999,"data":[{"name":"bulbasaur","id":1}]}"#;
         let envelope: Envelope<Vec<PokemonEntry>> = serde_json::from_slice(raw).unwrap();
         assert_ne!(envelope.version, VERSION);
+    }
+
+    /// A directory of our own under the system temp dir. The cache root is
+    /// resolved once per process and shared by every test, so the expiry tests
+    /// work on a path they own instead.
+    fn scratch_dir(label: &str) -> PathBuf {
+        static COUNTER: std::sync::atomic::AtomicU32 = std::sync::atomic::AtomicU32::new(0);
+        let n = COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        let dir = std::env::temp_dir().join(format!(
+            "pokeductor-test-{}-{label}-{n}",
+            std::process::id()
+        ));
+        std::fs::create_dir_all(&dir).expect("scratch dir");
+        dir
+    }
+
+    /// Rewinds a file's mtime, which is the only input to [`age`].
+    fn backdate(path: &Path, by: Duration) {
+        let file = std::fs::File::options()
+            .write(true)
+            .open(path)
+            .expect("open for touch");
+        let when = SystemTime::now() - by;
+        file.set_times(std::fs::FileTimes::new().set_modified(when))
+            .expect("backdate mtime");
+    }
+
+    #[tokio::test]
+    async fn a_species_never_looked_up_reads_as_a_miss() {
+        let dir = scratch_dir("never");
+        assert!(!sprite_answer_is_current(&dir.join("absent.png")).await);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[tokio::test]
+    async fn a_fresh_no_artwork_answer_still_suppresses_the_request() {
+        let dir = scratch_dir("fresh");
+        let path = dir.join("marker.png");
+        std::fs::write(&path, []).expect("write marker");
+        assert!(sprite_answer_is_current(&path).await);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[tokio::test]
+    async fn a_stale_no_artwork_answer_is_asked_again() {
+        let dir = scratch_dir("stale");
+        let path = dir.join("marker.png");
+        std::fs::write(&path, []).expect("write marker");
+        backdate(&path, MISSING_SPRITE_TTL + Duration::from_secs(60));
+        assert!(!sprite_answer_is_current(&path).await);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[tokio::test]
+    async fn a_cached_sprite_never_expires() {
+        let dir = scratch_dir("kept");
+        let path = dir.join("sprite.png");
+        std::fs::write(&path, b"not really a png, but not empty").expect("write sprite");
+        backdate(&path, MISSING_SPRITE_TTL * 52);
+        assert!(sprite_answer_is_current(&path).await);
+        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[test]

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -202,6 +202,23 @@ async fn sprite_answer_is_current(path: &Path) -> bool {
     age(path).await.is_some_and(|a| a < MISSING_SPRITE_TTL)
 }
 
+/// The `/pokemon` name a species' artwork is filed under, if we have ever
+/// resolved it. The mapping is a property of the species and never changes, so
+/// it is stored without an expiry — one request per species per install.
+pub async fn load_default_variety(species: &str) -> Option<String> {
+    let path = variety_path(species)?;
+    let name = tokio::fs::read_to_string(&path).await.ok()?;
+    let name = name.trim().to_string();
+    (!name.is_empty()).then_some(name)
+}
+
+pub async fn store_default_variety(species: &str, variety: &str) {
+    let Some(path) = variety_path(species) else {
+        return;
+    };
+    write_atomic(&path, variety.as_bytes()).await;
+}
+
 /// A machine translation of a flavor blurb. These cost a rate-limited
 /// third-party request, so they are the most valuable thing here to keep.
 pub async fn load_translation(name: &str, lang: &str) -> Option<String> {
@@ -260,6 +277,14 @@ fn sprite_path(name: &str, variant: SpriteVariant) -> Option<PathBuf> {
 /// name, or a shiny PNG would silently overwrite the normal one.
 fn sprite_file(name: &str, variant: SpriteVariant) -> String {
     format!("{}{}.png", slug(name), variant.file_suffix())
+}
+
+fn variety_path(species: &str) -> Option<PathBuf> {
+    Some(
+        root()?
+            .join("varieties")
+            .join(format!("{}.txt", slug(species))),
+    )
 }
 
 fn translation_path(name: &str, lang: &str) -> Option<PathBuf> {


### PR DESCRIPTION
Closes #12, closes #14.

## Resolve a species' default variety before asking for its artwork (#12)

Evolution chains carry **species** names (`giratina`), but `fetch_named_sprite`
resolved artwork through `/pokemon/{name}`, which is keyed on **variety** names.
For a species whose default form has its own name that endpoint 404s, so the card
drew its name and the `…` placeholder forever. `resolve_named_sprite` maps
`Err(_)` to `None` deliberately, so nothing was cached and the request was
re-issued and re-failed on every single run.

- `varieties` added to `RawSpecies`, plus a species → default-variety step in
  front of the chain-sprite path. The mapping is cached under `varieties/`, so
  the extra request happens once per species per install rather than once per
  view.
- A name that is already a variety (`raichu-alola`, straight out of the master
  list) has no species record of its own. That 404 means "the name is its own
  key", and is cached like any other answer.
- `ApiError::NotFound` separates a 404 from the transport failures
  `ApiError::Network` covers. A 404 says something durable about a name, so a
  genuinely unknown one is now written down instead of retried forever — while a
  timeout still never gets filed as "no artwork".

Verified against the live API, every species named in the issue:

| species | default variety | artwork |
| --- | --- | --- |
| giratina | giratina-altered | yes |
| toxtricity | toxtricity-amped | yes |
| basculegion | basculegion-male | yes |
| deoxys | deoxys-normal | yes |
| shaymin | shaymin-land | yes |
| wormadam | wormadam-plant | yes |
| lycanroc | lycanroc-midday | yes |

## Expire the "this species has no artwork" cache entry (#14)

The empty marker under `sprites/` never expired. Unlike stats or evolution
chains, artwork is not append-only history: PokeAPI backfills sprites for newly
added species, which are exactly the ones likely to be missing art the first time
anyone looks.

- `MISSING_SPRITE_TTL` of one week, checked through the existing `age()` helper.
  Successful entries stay permanent — a decoded PNG really is final.
- The three states `has_sprite_answer` distinguishes are now "never looked",
  "looked, and there is none", and "looked a while ago", the last reading as a
  miss.
- The decision is split into `sprite_answer_is_current` so the expiry can be
  tested against a real backdated file rather than through the process-wide cache
  root.

## Testing

- `cargo test` — 66 passing. New: three `default_variety_name` cases (a
  form-named species, an ordinary one, a payload marking no default at all) and
  four expiry cases (never looked / fresh marker / marker with a backdated mtime
  / an old but non-empty PNG).
- `cargo test -- --ignored` (live API) passes: `/pokemon-species/giratina` yields
  `giratina-altered` and its artwork decodes, and a bogus name now surfaces as
  `ApiError::NotFound` rather than a generic network error.
- `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` clean.

## Notes

- Existing installs still hold empty markers written by older builds. #14's TTL
  clears them within a week; an immediate fix means deleting the cache directory
  by hand, which is what the `--clear-cache` escape hatch in #5 is for.
- Pressing "jump to evolution member" on a species like Giratina still does
  nothing, because the master list carries variety names and `giratina` is not in
  it. That is #19's territory (alternate forms), left alone here.
