### PR TITLE
Add a command-line interface

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,6 +15,56 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
+name = "anstream"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
+name = "anstyle-parse"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -98,6 +148,52 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "clap"
+version = "4.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "473c7e07f409a8d772161724aa8db6a765a2532a70f9667eeb7b49d3d02fbdca"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b48fea5a88e9ae728a2dcbedbfc0e730f7d60da42e1cb049a83c9fb8b789889"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d012d2b9d65aca7f18f4d9878a045bc17899bba951561ba5ec3c2ba1eed9a061"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 3.0.4",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "compact_str"
@@ -194,7 +290,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -205,7 +301,7 @@ checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
  "darling_core",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -216,7 +312,7 @@ checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -247,7 +343,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -373,7 +469,7 @@ checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -746,7 +842,7 @@ dependencies = [
  "indoc",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -754,6 +850,12 @@ name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+
+[[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itertools"
@@ -912,6 +1014,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
 name = "openssl"
 version = "0.10.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -933,7 +1041,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1019,6 +1127,7 @@ name = "pokeductor"
 version = "0.3.1"
 dependencies = [
  "anyhow",
+ "clap",
  "crossterm",
  "futures",
  "image",
@@ -1046,7 +1155,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1186,7 +1295,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1305,7 +1414,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1435,7 +1544,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1449,6 +1558,17 @@ name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6275cddf4610d1775e6d1fe9469b2e77d0f39fd98fb7450901b821e0c53649f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1472,7 +1592,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1506,7 +1626,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1526,7 +1646,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1562,7 +1682,7 @@ checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1734,6 +1854,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
 name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1814,7 +1940,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wasm-bindgen-shared",
 ]
 
@@ -2055,7 +2181,7 @@ dependencies = [
  "heck",
  "indexmap",
  "prettyplease",
- "syn",
+ "syn 2.0.117",
  "wasm-metadata",
  "wit-bindgen-core",
  "wit-component",
@@ -2071,7 +2197,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wit-bindgen-core",
  "wit-bindgen-rust",
 ]
@@ -2138,7 +2264,7 @@ checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -2159,7 +2285,7 @@ checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -2199,7 +2325,7 @@ checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ futures = "0.3"
 anyhow = "1"
 thiserror = "2"
 image = { version = "0.25", default-features = false, features = ["png"] }
+clap = { version = "4.6.6", features = ["derive"] }
 
 [profile.release]
 opt-level = 3

--- a/README.md
+++ b/README.md
@@ -56,8 +56,10 @@ yay -S pokeductor
   has been viewed once it opens with no network at all; see
   [Caching](#caching).
 
-The first launch fetches the species list and opens on Bulbasaur. Moving through
-the list loads each Pokémon's details, evolution chain and artwork on demand.
+The first launch fetches the species list and opens on Bulbasaur — or on
+whatever you name, `pokeductor gengar`. Moving through the list loads each
+Pokémon's details, evolution chain and artwork on demand. See [Command
+line](#command-line) for the full set of flags.
 
 ---
 
@@ -226,6 +228,52 @@ or derive a generation from. A bare number still reaches them by name.
 
 ---
 
+## Command line
+
+```
+Usage: pokeductor [OPTIONS] [NAME]
+
+Arguments:
+  [NAME]  Open directly on this species, e.g. `pokeductor gengar`
+
+Options:
+      --lang <LANG>  Start in this UI language [possible values: en, tr, de, fr, es, it]
+      --clear-cache  Delete the on-disk cache and exit
+      --cache-dir    Print the cache directory and exit
+  -h, --help         Print help (see more with '--help')
+  -V, --version      Print version
+```
+
+`NAME` goes into the search box rather than through a parser of its own, so
+everything [the search syntax](#search-syntax) understands works here too:
+
+```bash
+pokeductor gengar          # straight to Gengar
+pokeductor 25              # Pokedex number 25 — Pikachu
+pokeductor type:ghost      # open with the list already filtered
+```
+
+An exact name wins the cursor even when something longer sorts ahead of it —
+`pokeductor mew` opens Mew, not Mewtwo — and a name that matches nothing leaves
+you on the same empty list typing it would have, with the query still in the
+box saying why.
+
+`--lang` outranks the language [the previous run left
+behind](#session-state) for this run, and being an ordinary choice like any
+made from the picker, it is what gets stored on the way out.
+
+The two cache commands answer the question this README used to answer with a
+path and a `rm -rf`. Both print what they touched:
+
+```console
+$ pokeductor --cache-dir
+/home/you/.cache/pokeductor
+$ pokeductor --clear-cache
+Removed /home/you/.cache/pokeductor
+```
+
+---
+
 ## Architecture
 
 A layered design. The rendering layer is a pure function of application state,
@@ -234,10 +282,11 @@ through to disk.
 
 | Module | Responsibility |
 |---|---|
-| `main.rs` | Entry point; terminal setup and the `tokio` runtime. |
+| `main.rs` | Entry point; argument handling, terminal setup and the `tokio` runtime. |
 | `models.rs` | API-agnostic domain types (`PokemonDetail`, `EvolutionTree`, `Sprite`, `Ability`). |
 | `api.rs` | Async PokeAPI client, evolution-chain parser, sprite decode, translation. |
 | `cache.rs` | On-disk cache of every fetched response, for instant and offline starts. |
+| `cli.rs` | Argument parsing, and the commands that answer without a terminal. |
 | `session.rs` | Party and preferences carried over from the previous run. |
 | `query.rs` | Search-box syntax (`dex:`, `type:`, `gen:`) parsing. |
 | `app.rs` | State machine and `tokio::select!` event loop (input · messages · animation tick). |
@@ -283,7 +332,8 @@ leave a half-written entry for the next one to read back as valid. Every entry
 is version-stamped: a build whose cached representation has changed shape treats
 older files as misses instead of mis-parsing them. The whole layer is
 best-effort — a cache that cannot be read or written is a miss, never an error
-the user sees. It is safe to delete at any time; it refills itself.
+the user sees. It is safe to delete at any time; it refills itself, and
+`--clear-cache` does it without anyone having to work out the path first.
 
 ### Session state
 
@@ -395,6 +445,7 @@ shown.
 
 [`ratatui`](https://crates.io/crates/ratatui) ·
 [`crossterm`](https://crates.io/crates/crossterm) ·
+[`clap`](https://crates.io/crates/clap) ·
 [`tokio`](https://crates.io/crates/tokio) ·
 [`reqwest`](https://crates.io/crates/reqwest) ·
 [`serde`](https://crates.io/crates/serde) ·

--- a/src/app.rs
+++ b/src/app.rs
@@ -17,6 +17,7 @@ use tokio::sync::mpsc;
 use crate::api;
 use crate::api::ApiError;
 use crate::cache;
+use crate::cli::Startup;
 use crate::i18n::Language;
 use crate::models::{
     AbilityInfo, EvolutionTree, PokemonDetail, PokemonEntry, Sprite, SpriteVariant,
@@ -180,6 +181,13 @@ pub struct App {
     pub translating: HashSet<(String, String)>,
     /// Name of the Pokemon currently shown in the detail panel.
     pub selected_name: Option<String>,
+    /// Language named on the command line, if any. Kept rather than merely
+    /// applied because the restored session carries a language too, and this
+    /// one has to outrank it.
+    cli_language: Option<Language>,
+    /// Species named on the command line, opened once the list arrives — the
+    /// first moment there is anything to resolve a name against.
+    startup_species: Option<String>,
     /// Name currently being fetched, if any (drives the detail spinner).
     pub loading_detail: Option<String>,
     pub list_loading: bool,
@@ -195,11 +203,14 @@ pub struct App {
 impl App {
     /// Builds the app and returns it alongside the receiver half of the
     /// message channel (handed back to [`App::run`]).
-    pub fn new() -> anyhow::Result<(Self, mpsc::Receiver<Message>)> {
+    ///
+    /// `startup` carries the command-line overrides. Each is optional, so a
+    /// bare invocation is the same call with nothing to override.
+    pub fn new(startup: Startup) -> anyhow::Result<(Self, mpsc::Receiver<Message>)> {
         let client = api::build_client()?;
         let (tx, rx) = mpsc::channel(64);
         let app = App {
-            language: Language::English,
+            language: startup.language.unwrap_or(Language::English),
             all_pokemon: Vec::new(),
             filtered: Vec::new(),
             list_state: ListState::default(),
@@ -228,6 +239,8 @@ impl App {
             translations: HashMap::new(),
             translating: HashSet::new(),
             selected_name: None,
+            cli_language: startup.language,
+            startup_species: startup.species,
             loading_detail: None,
             list_loading: false,
             error: None,
@@ -301,8 +314,14 @@ impl App {
     /// recognises, keeps its default rather than rejecting the file: a session
     /// is a convenience, and a partly understood one still beats starting over.
     fn restore(&mut self, session: Session) {
-        if let Some(language) = session.language.as_deref().and_then(Language::from_code) {
-            self.language = language;
+        // `--lang` is an explicit choice made for this run, so it outranks the
+        // one carried over from the last. What the run *ends* in is still what
+        // gets stored on the way out, which makes the flag behave exactly like
+        // opening the picker and choosing that language would.
+        if self.cli_language.is_none() {
+            if let Some(language) = session.language.as_deref().and_then(Language::from_code) {
+                self.language = language;
+            }
         }
         if let Some(sort) = session.sort.as_deref().and_then(SortKey::from_code) {
             self.sort = sort;
@@ -556,6 +575,30 @@ impl App {
             .insert(name, sprite);
     }
 
+    /// Puts the species named on the command line under the cursor, down the
+    /// same path a search-box query takes: the name goes into the box and the
+    /// list narrows to it. That is what makes `pokeductor 25` and
+    /// `pokeductor type:ghost` work without a second parser, and what keeps an
+    /// unknown name on the one "no results" path the TUI already has rather
+    /// than inventing a command-line error beside it. The query stays in the
+    /// box, so a list that narrowed to nothing says why it did.
+    ///
+    /// The one thing the search box cannot do here is prefer an exact match:
+    /// `mew` narrows to Mew and Mewtwo, and dex order puts Mewtwo first. That
+    /// is right when a human is about to press `↓`, and wrong as the answer to
+    /// `pokeductor mew`, so an exact name takes the cursor.
+    fn select_named_species(&mut self, name: String) {
+        self.query = name.trim().to_lowercase();
+        self.recompute_filter();
+        let exact = self
+            .filtered
+            .iter()
+            .position(|&idx| self.all_pokemon[idx].name == self.query);
+        if let Some(pos) = exact {
+            self.list_state.select(Some(pos));
+        }
+    }
+
     /// Loads the chain member currently under the evolution cursor — the quick
     /// "jump to my next evolution" action.
     fn jump_to_evolution_member(&mut self) {
@@ -582,8 +625,16 @@ impl App {
             Message::ListLoaded(list) => {
                 self.all_pokemon = list;
                 self.list_loading = false;
-                self.recompute_filter();
-                // Open on the first species (Bulbasaur) instead of an empty
+                // A species named on the command line goes through the
+                // search box, which is what narrows the list to it. With no
+                // argument the box is empty and the filter is the whole list.
+                if let Some(name) = self.startup_species.take() {
+                    self.select_named_species(name);
+                } else {
+                    self.recompute_filter();
+                }
+                // Open on whatever ended up under the cursor — the argument's
+                // species, or the first entry (Bulbasaur) — instead of an empty
                 // panel, so there is something to look at before any keypress.
                 if self.selected_name.is_none() {
                     self.request_selected();
@@ -1213,5 +1264,74 @@ mod tests {
     fn an_unknown_sort_code_is_not_guessed_at() {
         assert_eq!(SortKey::from_code("stat-total"), None);
         assert_eq!(SortKey::from_code(""), None);
+    }
+
+    /// An app with a list already in it and nothing in flight. `App::new`
+    /// touches no network of its own — it only builds the client the fetch
+    /// tasks would use — so this stays a plain unit test.
+    fn app_listing(entries: &[(u32, &str)]) -> App {
+        let (mut app, _rx) = App::new(Startup::default()).expect("client builds");
+        app.all_pokemon = entries
+            .iter()
+            .map(|&(id, name)| PokemonEntry {
+                name: name.to_string(),
+                id,
+            })
+            .collect();
+        app
+    }
+
+    #[test]
+    fn a_named_species_wins_the_cursor_over_the_longer_name_that_sorts_first() {
+        let mut app = app_listing(&[(150, "mewtwo"), (151, "mew")]);
+        app.select_named_species("Mew".to_string());
+
+        assert_eq!(app.query, "mew", "the box shows what narrowed the list");
+        assert_eq!(app.filtered.len(), 2, "Mewtwo still matches the text");
+        assert_eq!(app.current_name().as_deref(), Some("mew"));
+    }
+
+    #[test]
+    fn a_name_reaching_the_box_carries_its_search_syntax_with_it() {
+        let mut app = app_listing(&[(25, "pikachu"), (26, "raichu")]);
+        app.select_named_species("dex:26".to_string());
+
+        assert_eq!(app.current_name().as_deref(), Some("raichu"));
+    }
+
+    #[test]
+    fn a_name_matching_nothing_lands_on_the_empty_list_rather_than_an_error() {
+        let mut app = app_listing(&[(1, "bulbasaur")]);
+        app.select_named_species("gengr".to_string());
+
+        assert!(app.filtered.is_empty());
+        assert_eq!(app.current_name(), None, "nothing to load, nothing loaded");
+        assert_eq!(app.query, "gengr", "and the box says why the list is empty");
+    }
+
+    #[test]
+    fn a_lang_flag_outranks_the_language_the_last_run_left_behind() {
+        let (mut app, _rx) = App::new(Startup {
+            language: Some(Language::Turkish),
+            species: None,
+        })
+        .expect("client builds");
+        app.restore(Session {
+            language: Some("de".to_string()),
+            ..Session::default()
+        });
+
+        assert_eq!(app.language, Language::Turkish);
+    }
+
+    #[test]
+    fn without_the_flag_the_stored_language_is_still_what_comes_back() {
+        let (mut app, _rx) = App::new(Startup::default()).expect("client builds");
+        app.restore(Session {
+            language: Some("de".to_string()),
+            ..Session::default()
+        });
+
+        assert_eq!(app.language, Language::German);
     }
 }

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -233,6 +233,35 @@ pub async fn store_translation(name: &str, lang: &str, text: &str) {
     write_atomic(&path, text.as_bytes()).await;
 }
 
+// --- Cache management ----------------------------------------------------
+
+/// Where this build keeps its cache, if a directory could be worked out.
+///
+/// Exposed for the `--cache-dir` and `--clear-cache` commands, which exist
+/// because the answer was previously a matter of reading this file's docs and
+/// guessing at environment variables.
+pub fn dir() -> Option<&'static Path> {
+    root()
+}
+
+/// Removes the cache tree, reporting whether there was one to remove.
+///
+/// The only function here that is not best-effort. Everywhere else a failed
+/// filesystem operation is a cache miss and the app carries on; this one runs
+/// because the user named it, so "I could not delete it" is an answer they
+/// need rather than one to swallow. An absent directory is not a failure —
+/// the tree is gone either way, which is what was asked for.
+///
+/// Takes the path rather than reading [`root`] so a test can point it at a
+/// directory it owns.
+pub async fn clear(dir: &Path) -> std::io::Result<bool> {
+    match tokio::fs::remove_dir_all(dir).await {
+        Ok(()) => Ok(true),
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(false),
+        Err(err) => Err(err),
+    }
+}
+
 // --- Paths ---------------------------------------------------------------
 
 /// Root of the cache tree, resolved once per process.
@@ -394,6 +423,27 @@ mod tests {
             sprite_file("pikachu", SpriteVariant::Shiny),
             "pikachu.shiny.png"
         );
+    }
+
+    #[tokio::test]
+    async fn clearing_removes_the_tree_and_reports_that_it_did() {
+        let dir = scratch_dir("clear");
+        std::fs::create_dir_all(dir.join("species")).expect("nested entry");
+        std::fs::write(dir.join("species").join("mew.json"), b"{}").expect("entry");
+
+        assert!(
+            clear(&dir).await.expect("removable"),
+            "found a tree to remove"
+        );
+        assert!(!dir.exists());
+    }
+
+    #[tokio::test]
+    async fn clearing_a_cache_that_was_never_written_is_not_a_failure() {
+        let dir = scratch_dir("clear-absent");
+        std::fs::remove_dir_all(&dir).expect("start from nothing");
+
+        assert!(!clear(&dir).await.expect("absence is not an error"));
     }
 
     #[test]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,0 +1,198 @@
+//! Command-line front door.
+//!
+//! Pokeductor is a TUI first, and the flags here are deliberately narrow: they
+//! exist to get *into* the interface in the right state, not to reimplement it
+//! on the command line. The two cache operations are the exception. They have
+//! no keybinding because they are not something you do mid-session — they are
+//! what you reach for from a shell when something looks wrong, and until now
+//! they meant finding `$XDG_CACHE_HOME/pokeductor` by hand and guessing.
+//!
+//! Output here stays in English while the interface is translated. Clap writes
+//! its own help and errors in English regardless, so translating the handful of
+//! lines around them would make the surface less consistent, not more.
+
+use std::path::Path;
+
+use clap::builder::PossibleValue;
+use clap::{Parser, ValueEnum};
+
+use crate::cache;
+use crate::i18n::Language;
+
+/// A terminal Pokedex and evolution analyzer.
+#[derive(Debug, Parser)]
+#[command(version, about, long_about = None)]
+pub struct Cli {
+    /// Open directly on this species, e.g. `pokeductor gengar`
+    ///
+    /// Goes into the search box, so everything its syntax understands works
+    /// here too: `pokeductor 25` opens Pikachu, `pokeductor type:ghost` opens
+    /// the list already filtered.
+    #[arg(value_name = "NAME")]
+    name: Option<String>,
+
+    /// Start in this UI language
+    #[arg(long, value_enum, value_name = "LANG")]
+    lang: Option<Language>,
+
+    /// Delete the on-disk cache and exit
+    #[arg(long, conflicts_with_all = ["name", "lang", "cache_dir"])]
+    clear_cache: bool,
+
+    /// Print the cache directory and exit
+    #[arg(long, conflicts_with_all = ["name", "lang"])]
+    cache_dir: bool,
+}
+
+/// The state the arguments ask the TUI to open in.
+///
+/// Both fields are overrides rather than values: `None` means "whatever the
+/// previous session left behind", which is what keeps a bare `pokeductor` from
+/// having to know anything about session restore.
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct Startup {
+    pub language: Option<Language>,
+    pub species: Option<String>,
+}
+
+/// What the arguments amounted to.
+#[derive(Debug)]
+pub enum Outcome {
+    /// Done on the command line; the TUI never opens.
+    Handled,
+    /// Open the TUI in this state.
+    Launch(Startup),
+}
+
+/// Parses the process arguments and carries out anything that does not need a
+/// terminal. Exits the process on `--help`, `--version` or a bad argument,
+/// which is clap's job and its exit codes.
+pub async fn run() -> anyhow::Result<Outcome> {
+    dispatch(Cli::parse()).await
+}
+
+/// The half of [`run`] that does not touch the process arguments, so the
+/// behaviour is reachable from a test with a hand-built `Cli`.
+async fn dispatch(cli: Cli) -> anyhow::Result<Outcome> {
+    if cli.cache_dir {
+        println!("{}", cache_dir()?.display());
+        return Ok(Outcome::Handled);
+    }
+
+    if cli.clear_cache {
+        let dir = cache_dir()?;
+        if cache::clear(dir).await? {
+            println!("Removed {}", dir.display());
+        } else {
+            println!("Nothing to remove: {} does not exist", dir.display());
+        }
+        return Ok(Outcome::Handled);
+    }
+
+    Ok(Outcome::Launch(Startup {
+        language: cli.lang,
+        species: cli.name,
+    }))
+}
+
+/// The resolved cache directory, or an error explaining why there is none.
+///
+/// [`cache::dir`] answering `None` means no home directory could be worked
+/// out. The app itself treats that as "caching is off" and says nothing, since
+/// it can still do its job; here the directory *is* the subject of the command,
+/// so silence would leave the user with no idea what happened.
+fn cache_dir() -> anyhow::Result<&'static Path> {
+    cache::dir().ok_or_else(|| {
+        anyhow::anyhow!(
+            "could not work out a cache directory: set XDG_CACHE_HOME or HOME \
+             (LOCALAPPDATA on Windows)"
+        )
+    })
+}
+
+/// Accepted `--lang` values are derived from [`Language::ALL`] and the codes
+/// the app already stores sessions with, so a seventh language becomes a valid
+/// flag value by existing rather than by anyone remembering this file.
+impl ValueEnum for Language {
+    fn value_variants<'a>() -> &'a [Self] {
+        &Language::ALL
+    }
+
+    fn to_possible_value(&self) -> Option<PossibleValue> {
+        Some(PossibleValue::new(self.flavor_code()).help(self.label()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::CommandFactory;
+
+    fn parse(args: &[&str]) -> Result<Cli, clap::Error> {
+        Cli::try_parse_from(std::iter::once("pokeductor").chain(args.iter().copied()))
+    }
+
+    #[test]
+    fn the_command_definition_is_internally_consistent() {
+        Cli::command().debug_assert();
+    }
+
+    #[test]
+    fn a_bare_invocation_overrides_nothing() {
+        let cli = parse(&[]).expect("no arguments is valid");
+        assert_eq!(cli.name, None);
+        assert_eq!(cli.lang, None);
+    }
+
+    #[test]
+    fn a_positional_argument_is_the_species_to_open() {
+        assert_eq!(parse(&["gengar"]).unwrap().name.as_deref(), Some("gengar"));
+        // Search syntax reaches the same field rather than a second parser.
+        assert_eq!(
+            parse(&["type:ghost"]).unwrap().name.as_deref(),
+            Some("type:ghost")
+        );
+    }
+
+    #[test]
+    fn every_ui_language_is_an_accepted_lang_value() {
+        for language in Language::ALL {
+            let cli = parse(&["--lang", language.flavor_code()])
+                .unwrap_or_else(|_| panic!("--lang {} should parse", language.flavor_code()));
+            assert_eq!(cli.lang, Some(language));
+        }
+    }
+
+    #[test]
+    fn a_language_we_do_not_ship_is_rejected_rather_than_guessed_at() {
+        assert!(parse(&["--lang", "ja"]).is_err());
+        assert!(parse(&["--lang", "English"]).is_err());
+    }
+
+    #[test]
+    fn the_cache_commands_refuse_arguments_they_would_ignore() {
+        assert!(parse(&["--clear-cache", "--cache-dir"]).is_err());
+        assert!(parse(&["--clear-cache", "gengar"]).is_err());
+        assert!(parse(&["--cache-dir", "gengar"]).is_err());
+        assert!(parse(&["--cache-dir", "--lang", "tr"]).is_err());
+    }
+
+    #[test]
+    fn an_unknown_flag_is_an_error_rather_than_a_species_name() {
+        assert!(parse(&["--shiny"]).is_err());
+    }
+
+    #[tokio::test]
+    async fn arguments_that_ask_for_nothing_special_launch_the_tui() {
+        let outcome = dispatch(parse(&["gengar", "--lang", "tr"]).unwrap())
+            .await
+            .expect("launching needs no filesystem");
+        match outcome {
+            Outcome::Launch(startup) => {
+                assert_eq!(startup.species.as_deref(), Some("gengar"));
+                assert_eq!(startup.language, Some(Language::Turkish));
+            }
+            Outcome::Handled => panic!("nothing here is handled on the command line"),
+        }
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@
 //! Module layout:
 //! - `models`  : API-agnostic domain types (the data domain layer).
 //! - `cache`   : on-disk cache of everything fetched, for instant/offline starts.
+//! - `cli`     : argument parsing and the commands that need no terminal.
 //! - `i18n`    : `Language` enum + translation tables (EN / TR / DE).
 //! - `theme`   : Catppuccin Mocha palette and per-type colors.
 //! - `api`     : async PokeAPI client and evolution-chain parser.
@@ -17,6 +18,7 @@
 mod api;
 mod app;
 mod cache;
+mod cli;
 mod i18n;
 mod models;
 mod query;
@@ -31,7 +33,15 @@ use app::App;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    let (app, rx) = App::new()?;
+    // Argument handling comes first: `--help`, `--version` and the cache
+    // commands all answer without a terminal, and none of them should flicker
+    // through the alternate screen on the way.
+    let startup = match cli::run().await? {
+        cli::Outcome::Handled => return Ok(()),
+        cli::Outcome::Launch(startup) => startup,
+    };
+
+    let (app, rx) = App::new(startup)?;
 
     // `ratatui::init` enters the alternate screen, enables raw mode, and
     // installs a panic hook that restores the terminal on the way out.


### PR DESCRIPTION
Closes #5.

The binary took no arguments, so `pokeductor --version` — the first thing anyone types when filing a bug against a crate they installed with `cargo install` — did nothing, and the on-disk cache could only be managed by working out `$XDG_CACHE_HOME/pokeductor` by hand and deleting it.

Adds a `cli` module built on clap, kept deliberately narrow: the flags exist to get *into* the TUI in the right state, not to reimplement it on the command line. The two cache commands are the exception — they have no keybinding because they are what you reach for from a shell rather than mid-session.

```
Usage: pokeductor [OPTIONS] [NAME]

Arguments:
  [NAME]  Open directly on this species, e.g. `pokeductor gengar`

Options:
      --lang <LANG>  Start in this UI language [possible values: en, tr, de, fr, es, it]
      --clear-cache  Delete the on-disk cache and exit
      --cache-dir    Print the cache directory and exit
  -h, --help         Print help (see more with '--help')
  -V, --version      Print version
```

## Notes on the pieces

**`NAME` goes into the search box** rather than through a parser of its own. That is what makes `pokeductor 25` and `pokeductor type:ghost` work without a line of new syntax, and what keeps an unknown name on the one "no results" path the TUI already has — query still in the box saying why the list is empty — instead of a second error path beside it.

The box cannot do one thing by itself: `mew` narrows to Mew *and* Mewtwo, and dex order puts Mewtwo first. Right when a human is about to press `↓`, wrong as the answer to `pokeductor mew`, so an exact name takes the cursor.

**`--lang` derives its accepted values from `Language::ALL`** and the codes sessions are already stored with (`impl ValueEnum for Language`), so a seventh language becomes a valid flag value by existing rather than by anyone remembering this file. It outranks the language the previous run left behind, and is stored on exit like any choice made from the picker.

**The cache commands both print the path they resolved.** `cache::clear` is the one function in that module that is not best-effort: it runs because the user named it, so a failure to remove the tree is theirs to see. An absent directory is not a failure — the tree is gone either way, which is what was asked for. A cache path that cannot be resolved at all is an error here, though the app itself still treats it as "caching is off" and says nothing.

**The two cache flags conflict with `NAME` and `--lang`** rather than silently ignoring arguments that could not do anything.

`--color` from the issue body is deliberately left out: without the quantization from #4 it would be a flag that does nothing. #4 should add it, as that issue already proposes.

## Testing

13 new tests (8 `cli`, 2 `cache`, 3 `app`), 105 passing overall. `cargo fmt --check`, `cargo clippy -D warnings` and `cargo +1.88 check` are clean — clap's floor is 1.85, so the MSRV is unchanged.

Exercised by hand against the real binary: `--help`, `--version`, an unknown flag (exit 2), `--cache-dir`, `--clear-cache` twice over (removed, then nothing to remove), the flag conflicts, and an environment with no `HOME` (clear error, exit 1). In a terminal, `pokeductor gengar` opens straight on Gengar with the Gastly line in the evolution panel, and `pokeductor 25 --lang tr` opens Pikachu with the interface in Turkish.