### PR TITLE
Degrade gracefully on terminals without truecolor

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,10 @@ yay -S pokeductor
 
 - **Rust 1.88 or newer** (2021 edition) — via [rustup](https://rustup.rs/). Not
   needed for the AUR package, which builds it for you.
-- A **truecolor (24-bit) terminal**. Sprites are drawn as RGB half-blocks and
-  will look wrong on a 256-colour terminal.
+- A **truecolor (24-bit) terminal** for sprites at their best. Not a
+  requirement: a 256-colour terminal gets the artwork quantized to its palette,
+  and one with no colour at all gets the interface without sprites rather than a
+  field of blank blocks. See [Colour](#colour).
 - A font with **Unicode block and box-drawing glyphs** — any Nerd Font, Fira
   Code, JetBrains Mono, and most modern monospace fonts qualify.
 - An **internet connection** for anything not already cached. After a species
@@ -123,6 +125,29 @@ rendering bug.
 Only the palette on screen is fetched, so flipping the toggle never pulls down
 two full sets of artwork, and both are cached separately on disk. A species
 PokeAPI ships no shiny sprite for falls back to its normal one.
+
+### Colour
+
+Sprites are RGB half-blocks, so how they land depends on what the terminal can
+show. Rather than requiring 24-bit colour, Pokeductor works out what it has and
+renders to it:
+
+| Terminal | What you get |
+|---|---|
+| Truecolor (`COLORTERM=truecolor`) | The artwork as decoded, 24-bit. |
+| 256 colours | Sprites quantized to the xterm palette — the 6×6×6 cube plus the greyscale ramp — so they stay readable instead of being dropped by a terminal that cannot parse the escape. |
+| No colour (`NO_COLOR`, `TERM=dumb`, `--color=never`) | The full interface without sprites. A sprite with no colour is a rectangle of identical blocks, which says less than the placeholder the panels already fall back to. |
+
+Detection is deliberately conservative: `COLORTERM` is the only positive claim
+of 24-bit support that gets taken at its word, so a terminal announcing itself
+through `TERM` alone gets the 256-colour path even when it would in fact have
+managed truecolor. A coarser sprite is a much smaller cost than an unreadable
+one, and `--color=truecolor` is there for anyone who knows better.
+
+`NO_COLOR` is honoured, and `--color` outranks it — naming a depth on the
+command line answers the question the environment is being consulted about.
+With no colour to work with, the list cursor and the evolution highlight fall
+back to reverse video, so there is still always something showing where you are.
 
 ### Type matchups
 
@@ -237,11 +262,12 @@ Arguments:
   [NAME]  Open directly on this species, e.g. `pokeductor gengar`
 
 Options:
-      --lang <LANG>  Start in this UI language [possible values: en, tr, de, fr, es, it]
-      --clear-cache  Delete the on-disk cache and exit
-      --cache-dir    Print the cache directory and exit
-  -h, --help         Print help (see more with '--help')
-  -V, --version      Print version
+      --lang <LANG>   Start in this UI language [possible values: en, tr, de, fr, es, it]
+      --color <WHEN>  How much colour the terminal can show [default: auto] [possible values: auto, truecolor, 256, never]
+      --clear-cache   Delete the on-disk cache and exit
+      --cache-dir     Print the cache directory and exit
+  -h, --help          Print help (see more with '--help')
+  -V, --version       Print version
 ```
 
 `NAME` goes into the search box rather than through a parser of its own, so
@@ -261,6 +287,10 @@ box saying why.
 `--lang` outranks the language [the previous run left
 behind](#session-state) for this run, and being an ordinary choice like any
 made from the picker, it is what gets stored on the way out.
+
+`--color` overrides what [colour detection](#colour) concluded, in either
+direction: `--color=truecolor` on a terminal that never advertised it, or
+`--color=never` on one that did.
 
 The two cache commands answer the question this README used to answer with a
 path and a `rm -rf`. Both print what they touched:
@@ -287,6 +317,7 @@ through to disk.
 | `api.rs` | Async PokeAPI client, evolution-chain parser, sprite decode, translation. |
 | `cache.rs` | On-disk cache of every fetched response, for instant and offline starts. |
 | `cli.rs` | Argument parsing, and the commands that answer without a terminal. |
+| `color.rs` | Terminal colour-depth detection, and the per-frame degradation pass. |
 | `session.rs` | Party and preferences carried over from the previous run. |
 | `query.rs` | Search-box syntax (`dex:`, `type:`, `gen:`) parsing. |
 | `app.rs` | State machine and `tokio::select!` event loop (input · messages · animation tick). |
@@ -372,6 +403,36 @@ Area averaging rather than nearest-neighbour sampling is what keeps downscaled
 sprites smooth instead of leaving the hard outline pixels as ragged lines.
 Sprites are cached re-encoded as PNG rather than as raw RGBA: a few kilobytes
 compressed against ~36 KB flattened, and the decoder is already a dependency.
+
+### Colour depth
+
+Detection resolves once at startup — `COLORTERM`, then `TERM`, with `NO_COLOR`
+and `--color` on top — into a single `Depth` carried on the app. The renderer
+never sees it: every widget writes 24-bit colour as before, and the finished
+buffer is rewritten on its way out of `terminal.draw`, mapping each cell's
+foreground and background to a palette index or to nothing at all.
+
+Doing it over the buffer rather than at each call site is what makes it one rule
+instead of a condition threaded through nineteen hundred lines of rendering —
+and it catches the sprite cells for free, since by then they are ordinary
+coloured cells like any other.
+
+Quantization compares two candidates: the nearest colour in the xterm 6×6×6 cube
+and the nearest step on the 24-entry greyscale ramp. Both are needed because the
+ramp is far finer than the cube's diagonal, so a mid-grey has a near-exact match
+on one and a visible cast on the other. Every palette entry quantizes to itself,
+which is the invariant the tests pin down.
+
+One thing survives the loss of colour deliberately. The list cursor and the
+evolution highlight are written as a foreground/background pair *plus*
+`REVERSED` — which a coloured terminal simply swaps back, drawing exactly what
+it drew before, and a colourless one renders as reverse video. Written the
+usual way round the highlight bar would vanish under `--color=never`, and with
+it any way to tell where the cursor is.
+
+crossterm reads `NO_COLOR` itself and strips colour sequences when it is set, so
+an explicit `--color` also calls `force_color_output` to say which of the two
+answers won.
 
 ### Type and team analysis
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -18,6 +18,7 @@ use crate::api;
 use crate::api::ApiError;
 use crate::cache;
 use crate::cli::Startup;
+use crate::color::{self, Depth};
 use crate::i18n::Language;
 use crate::models::{
     AbilityInfo, EvolutionTree, PokemonDetail, PokemonEntry, Sprite, SpriteVariant,
@@ -181,6 +182,10 @@ pub struct App {
     pub translating: HashSet<(String, String)>,
     /// Name of the Pokemon currently shown in the detail panel.
     pub selected_name: Option<String>,
+    /// What the terminal can show, resolved once at startup from `--color` and
+    /// the environment. Every frame is rewritten into it on the way out, and
+    /// sprites are skipped entirely when it is [`Depth::None`].
+    pub color_depth: Depth,
     /// Language named on the command line, if any. Kept rather than merely
     /// applied because the restored session carries a language too, and this
     /// one has to outrank it.
@@ -208,6 +213,8 @@ impl App {
     /// bare invocation is the same call with nothing to override.
     pub fn new(startup: Startup) -> anyhow::Result<(Self, mpsc::Receiver<Message>)> {
         let client = api::build_client()?;
+        let color_depth = color::resolve(startup.color, &color::Env::from_process());
+        color::enforce(startup.color, color_depth);
         let (tx, rx) = mpsc::channel(64);
         let app = App {
             language: startup.language.unwrap_or(Language::English),
@@ -239,6 +246,7 @@ impl App {
             translations: HashMap::new(),
             translating: HashSet::new(),
             selected_name: None,
+            color_depth,
             cli_language: startup.language,
             startup_species: startup.species,
             loading_detail: None,
@@ -271,7 +279,16 @@ impl App {
             // selection+language needs one and none is cached or in flight.
             self.ensure_translation();
             self.ensure_ability_info();
-            terminal.draw(|frame| crate::ui::render(frame, &mut self))?;
+            // Rendering always writes 24-bit colour; this is where the frame
+            // is rewritten into what the terminal can actually show. Doing it
+            // over the finished buffer keeps every widget — and every sprite
+            // pixel — degrading by one rule instead of each checking for
+            // itself.
+            let depth = self.color_depth;
+            terminal.draw(|frame| {
+                crate::ui::render(frame, &mut self);
+                color::degrade(frame.buffer_mut(), depth);
+            })?;
 
             tokio::select! {
                 maybe_msg = rx.recv() => {
@@ -505,6 +522,14 @@ impl App {
     /// an alternate form (`raichu-alola`) does not appear in it under its own
     /// name — the chain carries the base species.
     fn ensure_visible_sprites(&mut self) {
+        // Nothing on screen will show them, and `sprite_for` says as much, so
+        // without this the loop below would re-request every chain member on
+        // every frame and never be satisfied. The artwork arriving inside a
+        // species bundle is still kept: it costs no request of its own, and it
+        // means a later run with colour opens instantly.
+        if self.color_depth == Depth::None {
+            return;
+        }
         let variant = self.sprite_variant;
         let names: Vec<String> = self
             .selected_name
@@ -558,6 +583,12 @@ impl App {
 
     /// Decoded artwork for `name` in the palette currently on display.
     pub fn sprite_for(&self, name: &str) -> Option<&Sprite> {
+        // A sprite drawn without colour is a rectangle of identical blocks,
+        // which says less than the placeholder the panels already fall back
+        // to. Answering `None` here is what routes both of them to it.
+        if self.color_depth == Depth::None {
+            return None;
+        }
         self.sprites.get(&self.sprite_variant)?.get(name)
     }
 
@@ -1313,7 +1344,7 @@ mod tests {
     fn a_lang_flag_outranks_the_language_the_last_run_left_behind() {
         let (mut app, _rx) = App::new(Startup {
             language: Some(Language::Turkish),
-            species: None,
+            ..Startup::default()
         })
         .expect("client builds");
         app.restore(Session {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -17,6 +17,7 @@ use clap::builder::PossibleValue;
 use clap::{Parser, ValueEnum};
 
 use crate::cache;
+use crate::color::Choice;
 use crate::i18n::Language;
 
 /// A terminal Pokedex and evolution analyzer.
@@ -35,12 +36,16 @@ pub struct Cli {
     #[arg(long, value_enum, value_name = "LANG")]
     lang: Option<Language>,
 
+    /// How much colour the terminal can show
+    #[arg(long, value_enum, value_name = "WHEN", default_value = "auto")]
+    color: Choice,
+
     /// Delete the on-disk cache and exit
-    #[arg(long, conflicts_with_all = ["name", "lang", "cache_dir"])]
+    #[arg(long, conflicts_with_all = ["name", "lang", "color", "cache_dir"])]
     clear_cache: bool,
 
     /// Print the cache directory and exit
-    #[arg(long, conflicts_with_all = ["name", "lang"])]
+    #[arg(long, conflicts_with_all = ["name", "lang", "color"])]
     cache_dir: bool,
 }
 
@@ -53,6 +58,10 @@ pub struct Cli {
 pub struct Startup {
     pub language: Option<Language>,
     pub species: Option<String>,
+    /// Colour depth to force, or [`Choice::Auto`] to work it out from the
+    /// environment. Unlike the other two this is never `None`: "detect it"
+    /// is itself one of the answers rather than the absence of one.
+    pub color: Choice,
 }
 
 /// What the arguments amounted to.
@@ -92,6 +101,7 @@ async fn dispatch(cli: Cli) -> anyhow::Result<Outcome> {
     Ok(Outcome::Launch(Startup {
         language: cli.lang,
         species: cli.name,
+        color: cli.color,
     }))
 }
 
@@ -108,6 +118,30 @@ fn cache_dir() -> anyhow::Result<&'static Path> {
              (LOCALAPPDATA on Windows)"
         )
     })
+}
+
+/// The `--color` values. Spelled for the command line rather than after the
+/// variants: `256` is what anyone reaching for this flag would type, and
+/// `never` says what it does to the interface rather than which encoding it
+/// stops using.
+impl ValueEnum for Choice {
+    fn value_variants<'a>() -> &'a [Self] {
+        &[
+            Choice::Auto,
+            Choice::Truecolor,
+            Choice::Ansi256,
+            Choice::Never,
+        ]
+    }
+
+    fn to_possible_value(&self) -> Option<PossibleValue> {
+        Some(match self {
+            Choice::Auto => PossibleValue::new("auto").help("Detect from COLORTERM and TERM"),
+            Choice::Truecolor => PossibleValue::new("truecolor").help("Force 24-bit colour"),
+            Choice::Ansi256 => PossibleValue::new("256").help("Force the 256-colour palette"),
+            Choice::Never => PossibleValue::new("never").help("No colour, and no sprites"),
+        })
+    }
 }
 
 /// Accepted `--lang` values are derived from [`Language::ALL`] and the codes
@@ -170,11 +204,41 @@ mod tests {
     }
 
     #[test]
+    fn colour_defaults_to_working_it_out_from_the_environment() {
+        assert_eq!(parse(&[]).unwrap().color, Choice::Auto);
+    }
+
+    #[test]
+    fn every_colour_depth_is_reachable_by_the_name_it_is_offered_under() {
+        let expected = [
+            ("auto", Choice::Auto),
+            ("truecolor", Choice::Truecolor),
+            ("256", Choice::Ansi256),
+            ("never", Choice::Never),
+        ];
+        for (value, choice) in expected {
+            assert_eq!(parse(&["--color", value]).unwrap().color, choice);
+        }
+        assert_eq!(
+            expected.len(),
+            Choice::value_variants().len(),
+            "every variant should have a spelling the tests cover"
+        );
+    }
+
+    #[test]
+    fn a_colour_depth_we_cannot_render_is_rejected() {
+        assert!(parse(&["--color", "16"]).is_err());
+        assert!(parse(&["--color", "always"]).is_err());
+    }
+
+    #[test]
     fn the_cache_commands_refuse_arguments_they_would_ignore() {
         assert!(parse(&["--clear-cache", "--cache-dir"]).is_err());
         assert!(parse(&["--clear-cache", "gengar"]).is_err());
         assert!(parse(&["--cache-dir", "gengar"]).is_err());
         assert!(parse(&["--cache-dir", "--lang", "tr"]).is_err());
+        assert!(parse(&["--clear-cache", "--color", "never"]).is_err());
     }
 
     #[test]
@@ -191,6 +255,7 @@ mod tests {
             Outcome::Launch(startup) => {
                 assert_eq!(startup.species.as_deref(), Some("gengar"));
                 assert_eq!(startup.language, Some(Language::Turkish));
+                assert_eq!(startup.color, Choice::Auto);
             }
             Outcome::Handled => panic!("nothing here is handled on the command line"),
         }

--- a/src/color.rs
+++ b/src/color.rs
@@ -1,0 +1,414 @@
+//! Terminal colour depth: what the terminal can show, and how to get there.
+//!
+//! Sprites are drawn as 24-bit RGB half-blocks. A terminal that does not
+//! understand those escapes does not fall back gracefully — it drops them, and
+//! the artwork comes out as a solid block of whatever the default colour is.
+//! That is not a niche configuration: `screen`, an older `tmux`, a plain
+//! `TERM=xterm-256color` with no `COLORTERM`, and a fair number of corporate
+//! emulators all land there.
+//!
+//! So we work out what the terminal can do and meet it: 24-bit where it is
+//! supported, the xterm-256 palette where it is not, and no colour at all when
+//! the user says so. The mapping happens once per frame over the finished
+//! buffer rather than at each call site, which is what keeps every colour in
+//! the app — sprite pixels, borders, type chips — degrading by the same rule.
+
+use ratatui::buffer::Buffer;
+use ratatui::style::{Color, Modifier};
+
+/// What the terminal can display.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Depth {
+    /// 24-bit RGB, emitted as written.
+    Truecolor,
+    /// The 256-colour palette: the 6x6x6 cube plus the greyscale ramp.
+    Ansi256,
+    /// No colour at all. Sprites are skipped rather than drawn as a field of
+    /// identical blocks, which is also what makes the interface legible to a
+    /// screen reader or in a captured log.
+    None,
+}
+
+/// What the user asked for, ahead of what we would have detected.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum Choice {
+    /// Work it out from the environment.
+    #[default]
+    Auto,
+    Truecolor,
+    Ansi256,
+    Never,
+}
+
+/// The environment variables detection reads.
+///
+/// Taken as a value rather than read inline so [`detect`] stays a pure
+/// function of its inputs — testable across the combinations that matter
+/// without a test mutating the process environment out from under its
+/// neighbours.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct Env {
+    pub colorterm: Option<String>,
+    pub term: Option<String>,
+    pub no_color: Option<String>,
+}
+
+impl Env {
+    /// The real environment. A variable set to the empty string reads as unset:
+    /// that is what [`NO_COLOR`](https://no-color.org/) specifies, and an empty
+    /// `TERM` carries no more information than a missing one.
+    pub fn from_process() -> Self {
+        let var = |key: &str| std::env::var(key).ok().filter(|v| !v.is_empty());
+        Env {
+            colorterm: var("COLORTERM"),
+            term: var("TERM"),
+            no_color: var("NO_COLOR"),
+        }
+    }
+}
+
+/// The depth to render at, given the flag and the environment.
+///
+/// An explicit `--color` outranks everything, `NO_COLOR` included: someone who
+/// names a depth on the command line has already answered the question the
+/// environment is being consulted about.
+pub fn resolve(choice: Choice, env: &Env) -> Depth {
+    match choice {
+        Choice::Truecolor => Depth::Truecolor,
+        Choice::Ansi256 => Depth::Ansi256,
+        Choice::Never => Depth::None,
+        Choice::Auto => detect(env),
+    }
+}
+
+/// Tells crossterm what we decided, where that differs from what it would
+/// have concluded on its own.
+///
+/// crossterm reads `NO_COLOR` itself and drops every colour sequence when it is
+/// set. That is the right default and it agrees with [`detect`] — but it also
+/// means an explicit `--color=truecolor` would be silently stripped on the way
+/// out, leaving us claiming a depth the frames never reach the terminal in.
+/// A depth the user named outranks the environment, so we say so here.
+/// Modifiers are untouched by this, so the reverse-video highlight survives
+/// either way.
+pub fn enforce(choice: Choice, depth: Depth) {
+    if choice != Choice::Auto {
+        crossterm::style::force_color_output(depth != Depth::None);
+    }
+}
+
+/// Works out what the terminal supports from `COLORTERM` and `TERM`.
+///
+/// This is a heuristic — there is no reliable query — so it is deliberately
+/// conservative in the middle. `COLORTERM` is the only positive claim of
+/// 24-bit support that can be trusted, and a terminal that announces itself
+/// through `TERM` alone gets the 256-colour path even when it would in fact
+/// have managed truecolor: a slightly coarser sprite is a much smaller cost
+/// than an unreadable one, and `--color=truecolor` is there for anyone who
+/// knows better.
+///
+/// An absent `TERM` is the exception, and it is Windows: the modern console
+/// sets neither variable and handles 24-bit fine. It is also what this app
+/// assumed unconditionally before any of this existed, so it is the least
+/// surprising place for the unknown case to land.
+pub fn detect(env: &Env) -> Depth {
+    if env.no_color.is_some() {
+        return Depth::None;
+    }
+
+    let term = env.term.as_deref();
+    if term == Some("dumb") {
+        return Depth::None;
+    }
+
+    let claims_truecolor = |value: &str| {
+        value.eq_ignore_ascii_case("truecolor") || value.eq_ignore_ascii_case("24bit")
+    };
+    if env.colorterm.as_deref().is_some_and(claims_truecolor) {
+        return Depth::Truecolor;
+    }
+
+    match term {
+        Some(term) if term.contains("truecolor") || term.contains("24bit") => Depth::Truecolor,
+        Some(_) => Depth::Ansi256,
+        None => Depth::Truecolor,
+    }
+}
+
+/// Rewrites a rendered frame into what the terminal can actually show.
+///
+/// Running over the finished buffer rather than at each call site is what makes
+/// this one rule instead of a condition threaded through every widget: whatever
+/// the renderer produced, in whatever palette, arrives here as plain colours to
+/// be mapped.
+pub fn degrade(buffer: &mut Buffer, depth: Depth) {
+    match depth {
+        Depth::Truecolor => {}
+        Depth::Ansi256 => {
+            for cell in &mut buffer.content {
+                cell.fg = indexed(cell.fg);
+                cell.bg = indexed(cell.bg);
+            }
+        }
+        Depth::None => {
+            for cell in &mut buffer.content {
+                cell.fg = Color::Reset;
+                cell.bg = Color::Reset;
+            }
+        }
+    }
+}
+
+/// The 256-colour equivalent of one colour. Anything already expressed in
+/// terms the terminal defines — an index, or its default — is left alone.
+fn indexed(color: Color) -> Color {
+    match color {
+        Color::Rgb(r, g, b) => Color::Indexed(quantize(r, g, b)),
+        other => other,
+    }
+}
+
+/// The six values each channel of the xterm colour cube can take. Note the gap:
+/// the step from 0 to 95 is far larger than the ones above it, which is why
+/// dark colours are the ones the cube approximates worst and why the greyscale
+/// ramp is worth consulting separately.
+const CUBE_LEVELS: [u8; 6] = [0, 95, 135, 175, 215, 255];
+
+/// The nearest xterm-256 palette index to an RGB colour.
+///
+/// Two candidates are compared: the closest colour in the 6x6x6 cube
+/// (indices 16-231) and the closest step on the 24-entry greyscale ramp
+/// (232-255). Greys are why both are needed — the ramp is far finer than the
+/// cube's diagonal, so `(120, 120, 120)` has a near-exact match on one and a
+/// visible cast on the other.
+pub fn quantize(r: u8, g: u8, b: u8) -> u8 {
+    let level = |channel: u8| -> usize {
+        CUBE_LEVELS
+            .iter()
+            .enumerate()
+            .min_by_key(|(_, &level)| (level as i32 - channel as i32).abs())
+            .map(|(index, _)| index)
+            .unwrap_or(0)
+    };
+    let (ri, gi, bi) = (level(r), level(g), level(b));
+    let cube_index = 16 + 36 * ri + 6 * gi + bi;
+    let cube_distance = distance(
+        (r, g, b),
+        (CUBE_LEVELS[ri], CUBE_LEVELS[gi], CUBE_LEVELS[bi]),
+    );
+
+    // The ramp runs 8, 18, ... 238, so the nearest step is found by rounding
+    // the average channel rather than searching.
+    let average = (r as u32 + g as u32 + b as u32) / 3;
+    let step = (average.saturating_sub(3) / 10).min(23);
+    let grey = (8 + 10 * step) as u8;
+    let grey_distance = distance((r, g, b), (grey, grey, grey));
+
+    if grey_distance < cube_distance {
+        (232 + step) as u8
+    } else {
+        cube_index as u8
+    }
+}
+
+/// Squared distance between two colours. Squared because only the comparison
+/// matters and the square root would not change which side of it we land on.
+fn distance(a: (u8, u8, u8), b: (u8, u8, u8)) -> u32 {
+    let channel = |x: u8, y: u8| {
+        let d = x as i32 - y as i32;
+        (d * d) as u32
+    };
+    channel(a.0, b.0) + channel(a.1, b.1) + channel(a.2, b.2)
+}
+
+/// A style that reads as a selection whether or not colour survives.
+///
+/// `REVERSED` on top of an ordinary foreground/background pair is what a
+/// coloured terminal was going to draw anyway — it swaps them back — while on a
+/// terminal rendering no colour at all it is the one distinction still
+/// available. Written the other way round (background set directly, no
+/// modifier) the highlight bar simply disappears under [`Depth::None`], and
+/// with it any way to tell where the cursor is.
+pub fn highlight(color: Color) -> ratatui::style::Style {
+    ratatui::style::Style::default()
+        .fg(color)
+        .bg(crate::theme::BASE)
+        .add_modifier(Modifier::REVERSED)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn env(colorterm: Option<&str>, term: Option<&str>) -> Env {
+        Env {
+            colorterm: colorterm.map(str::to_string),
+            term: term.map(str::to_string),
+            no_color: None,
+        }
+    }
+
+    /// The RGB the terminal shows for a palette index, so the round trip below
+    /// has something to compare against.
+    fn palette_rgb(index: u8) -> (u8, u8, u8) {
+        if index >= 232 {
+            let grey = 8 + 10 * (index as u16 - 232);
+            (grey as u8, grey as u8, grey as u8)
+        } else {
+            let n = index as usize - 16;
+            (
+                CUBE_LEVELS[n / 36],
+                CUBE_LEVELS[(n / 6) % 6],
+                CUBE_LEVELS[n % 6],
+            )
+        }
+    }
+
+    #[test]
+    fn every_palette_colour_quantizes_to_itself() {
+        for index in 16..=255u8 {
+            let (r, g, b) = palette_rgb(index);
+            assert_eq!(
+                quantize(r, g, b),
+                index,
+                "index {index} ({r}, {g}, {b}) should be its own nearest match"
+            );
+        }
+    }
+
+    #[test]
+    fn greys_prefer_the_ramp_over_the_cube_diagonal() {
+        // 120 sits between the cube's 95 and 135 and almost exactly on a ramp
+        // step, which is the case the ramp exists for.
+        let index = quantize(120, 120, 120);
+        assert!(index >= 232, "expected a greyscale index, got {index}");
+        assert_eq!(palette_rgb(index), (118, 118, 118));
+    }
+
+    #[test]
+    fn a_saturated_colour_takes_the_cube() {
+        let index = quantize(255, 0, 0);
+        assert_eq!(index, 196);
+        assert_eq!(palette_rgb(index), (255, 0, 0));
+    }
+
+    #[test]
+    fn colorterm_is_the_one_claim_of_truecolor_we_take_at_its_word() {
+        assert_eq!(
+            detect(&env(Some("truecolor"), Some("xterm"))),
+            Depth::Truecolor
+        );
+        assert_eq!(detect(&env(Some("24bit"), Some("xterm"))), Depth::Truecolor);
+        assert_eq!(detect(&env(Some("TrueColor"), None)), Depth::Truecolor);
+    }
+
+    #[test]
+    fn a_256_colour_term_without_colorterm_gets_the_palette() {
+        assert_eq!(detect(&env(None, Some("xterm-256color"))), Depth::Ansi256);
+        assert_eq!(detect(&env(None, Some("screen-256color"))), Depth::Ansi256);
+        // A COLORTERM saying something else is not a claim of 24-bit support.
+        assert_eq!(
+            detect(&env(Some("8bit"), Some("xterm-256color"))),
+            Depth::Ansi256
+        );
+    }
+
+    #[test]
+    fn a_term_we_have_never_heard_of_gets_the_conservative_answer() {
+        assert_eq!(detect(&env(None, Some("vt220"))), Depth::Ansi256);
+        assert_eq!(detect(&env(None, Some("linux"))), Depth::Ansi256);
+    }
+
+    #[test]
+    fn a_terminal_that_names_itself_truecolor_is_believed_too() {
+        assert_eq!(
+            detect(&env(None, Some("xterm-truecolor"))),
+            Depth::Truecolor
+        );
+    }
+
+    #[test]
+    fn no_term_at_all_is_windows_and_keeps_its_colour() {
+        assert_eq!(detect(&env(None, None)), Depth::Truecolor);
+    }
+
+    #[test]
+    fn a_dumb_terminal_gets_no_colour() {
+        assert_eq!(detect(&env(Some("truecolor"), Some("dumb"))), Depth::None);
+    }
+
+    #[test]
+    fn no_color_wins_over_anything_the_terminal_advertises() {
+        let mut env = env(Some("truecolor"), Some("xterm-256color"));
+        env.no_color = Some("1".to_string());
+        assert_eq!(detect(&env), Depth::None);
+        // Per the convention, the value is irrelevant; only presence counts.
+        env.no_color = Some("0".to_string());
+        assert_eq!(detect(&env), Depth::None);
+    }
+
+    #[test]
+    fn an_empty_variable_is_the_same_as_an_unset_one() {
+        // `Env::from_process` filters these out, so detection never sees them;
+        // this pins the behaviour that filter is there to produce.
+        assert_eq!(detect(&Env::default()), Depth::Truecolor);
+    }
+
+    #[test]
+    fn the_flag_outranks_both_the_terminal_and_no_color() {
+        let mut hostile = env(None, Some("dumb"));
+        hostile.no_color = Some("1".to_string());
+
+        assert_eq!(resolve(Choice::Truecolor, &hostile), Depth::Truecolor);
+        assert_eq!(resolve(Choice::Ansi256, &hostile), Depth::Ansi256);
+        assert_eq!(
+            resolve(Choice::Never, &env(Some("truecolor"), None)),
+            Depth::None
+        );
+        assert_eq!(resolve(Choice::Auto, &hostile), Depth::None);
+    }
+
+    fn painted(color: Color) -> Buffer {
+        let mut buffer = Buffer::empty(ratatui::layout::Rect::new(0, 0, 1, 1));
+        buffer.content[0].fg = color;
+        buffer.content[0].bg = color;
+        buffer
+    }
+
+    #[test]
+    fn truecolor_leaves_the_frame_exactly_as_rendered() {
+        let mut buffer = painted(Color::Rgb(1, 2, 3));
+        degrade(&mut buffer, Depth::Truecolor);
+        assert_eq!(buffer.content[0].fg, Color::Rgb(1, 2, 3));
+    }
+
+    #[test]
+    fn the_palette_pass_rewrites_both_halves_of_a_half_block_cell() {
+        let mut buffer = painted(Color::Rgb(255, 0, 0));
+        degrade(&mut buffer, Depth::Ansi256);
+        assert_eq!(buffer.content[0].fg, Color::Indexed(196));
+        assert_eq!(buffer.content[0].bg, Color::Indexed(196));
+    }
+
+    #[test]
+    fn a_colour_the_terminal_already_defines_is_passed_through_untouched() {
+        let mut buffer = painted(Color::Indexed(42));
+        degrade(&mut buffer, Depth::Ansi256);
+        assert_eq!(buffer.content[0].fg, Color::Indexed(42));
+
+        let mut buffer = painted(Color::Reset);
+        degrade(&mut buffer, Depth::Ansi256);
+        assert_eq!(buffer.content[0].fg, Color::Reset);
+    }
+
+    #[test]
+    fn no_colour_leaves_the_modifiers_that_carry_meaning_without_it() {
+        let mut buffer = painted(Color::Rgb(255, 236, 39));
+        buffer.content[0].modifier = Modifier::REVERSED;
+        degrade(&mut buffer, Depth::None);
+
+        assert_eq!(buffer.content[0].fg, Color::Reset);
+        assert_eq!(buffer.content[0].bg, Color::Reset);
+        assert_eq!(buffer.content[0].modifier, Modifier::REVERSED);
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@
 //! - `models`  : API-agnostic domain types (the data domain layer).
 //! - `cache`   : on-disk cache of everything fetched, for instant/offline starts.
 //! - `cli`     : argument parsing and the commands that need no terminal.
+//! - `color`   : terminal colour-depth detection and per-frame degradation.
 //! - `i18n`    : `Language` enum + translation tables (EN / TR / DE).
 //! - `theme`   : Catppuccin Mocha palette and per-type colors.
 //! - `api`     : async PokeAPI client and evolution-chain parser.
@@ -19,6 +20,7 @@ mod api;
 mod app;
 mod cache;
 mod cli;
+mod color;
 mod i18n;
 mod models;
 mod query;

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -8,6 +8,7 @@ use ratatui::widgets::{Block, BorderType, Clear, List, ListItem, Paragraph, Wrap
 use ratatui::Frame;
 
 use crate::app::{App, Focus, SortKey};
+use crate::color;
 use crate::i18n::{EvoStrings, Language, Strings};
 use crate::models::{title_case, EvolutionTree, Sprite};
 use crate::team::{self, AbilityImmunity};
@@ -178,12 +179,9 @@ fn render_sidebar(frame: &mut Frame, app: &mut App, s: &Strings, area: Rect) {
         })
         .collect();
 
-    let list = List::new(items).highlight_symbol("▶ ").highlight_style(
-        Style::default()
-            .fg(theme::BASE)
-            .bg(theme::MAUVE)
-            .add_modifier(Modifier::BOLD),
-    );
+    let list = List::new(items)
+        .highlight_symbol("▶ ")
+        .highlight_style(color::highlight(theme::MAUVE).add_modifier(Modifier::BOLD));
     frame.render_stateful_widget(list, inner, &mut app.list_state);
 }
 
@@ -958,10 +956,7 @@ fn draw_card(
     let is_cursor = cursor == Some(node.name.as_str());
     let is_current = current == Some(node.name.as_str());
     let style = if is_cursor {
-        Style::default()
-            .fg(theme::BASE)
-            .bg(theme::YELLOW)
-            .add_modifier(Modifier::BOLD)
+        color::highlight(theme::YELLOW).add_modifier(Modifier::BOLD)
     } else if is_current {
         Style::default()
             .fg(theme::YELLOW)
@@ -1692,10 +1687,7 @@ fn render_language_picker(frame: &mut Frame, app: &App, s: &Strings, full: Rect)
         let marker = if active { "●" } else { "○" };
         let label = format!(" {marker} {:<10} {} ", lang.label(), lang.tag());
         let style = if selected {
-            Style::default()
-                .fg(theme::BASE)
-                .bg(theme::MAUVE)
-                .add_modifier(Modifier::BOLD)
+            color::highlight(theme::MAUVE).add_modifier(Modifier::BOLD)
         } else if active {
             Style::default().fg(theme::MAUVE)
         } else {


### PR DESCRIPTION
Closes #4. **Stacked on #23** — base is `feat/cli`, since the `--color` flag belongs to the CLI that lands there. Retarget to `main` once #23 merges.

Sprites are drawn as 24-bit RGB half-blocks, and a terminal that does not understand those escapes does not approximate them — it drops them, leaving the artwork as a solid block of the default colour. The README documented this as a requirement rather than handling it, and there was no detection anywhere: `COLORTERM` and `TERM` were never read.

Adds a `color` module holding three things — detection, quantization, and the pass that applies them.

## Detection

Resolves once at startup into a `Depth` carried on the app. Deliberately conservative in the middle: `COLORTERM` is the only positive claim of 24-bit support taken at its word, so a terminal announcing itself through `TERM` alone gets the 256-colour path even where it would in fact have managed truecolor. A coarser sprite is a much smaller cost than an unreadable one, and `--color=truecolor` is there for anyone who knows better.

An absent `TERM` is the exception, and it is Windows: the modern console sets neither variable and handles 24-bit fine. It is also what this app assumed unconditionally until now, so it is the least surprising place for the unknown case to land.

`detect` is a pure function of `(COLORTERM, TERM, NO_COLOR)`, so the tests cover the combinations without mutating the process environment.

## The degradation pass

Runs over the finished buffer inside `terminal.draw` rather than at each call site:

```rust
terminal.draw(|frame| {
    crate::ui::render(frame, &mut self);
    color::degrade(frame.buffer_mut(), depth);
})?;
```

That is what keeps it one rule instead of a condition threaded through nineteen hundred lines of rendering — and it catches the sprite cells for free, since by then they are ordinary coloured cells like any other. `ui.rs` and `theme.rs` are otherwise untouched.

Quantization compares the nearest colour in the xterm 6×6×6 cube against the nearest step on the 24-entry greyscale ramp. Both are needed: the ramp is far finer than the cube's diagonal, so a mid-grey has a near-exact match on one and a visible cast on the other. Every palette entry quantizes to itself, which is what the round-trip test asserts across all 240 of them.

## No colour at all

Sprites are skipped rather than drawn as a field of identical blocks: `sprite_for` answers `None`, which routes both panels to the placeholder they already fall back to, and `ensure_visible_sprites` returns early so it does not re-request artwork nothing will show. (That early return is load-bearing, not just an optimisation — without it the "do I already have this sprite" check never comes back true.)

One thing survives deliberately. The list cursor and the evolution highlight are now written as a colour pair *plus* `REVERSED`, which a coloured terminal swaps back into exactly what it drew before, and a colourless one renders as reverse video. Written the usual way round the highlight bar simply vanishes, and with it any way to tell where the cursor is.

crossterm reads `NO_COLOR` itself and strips colour sequences when it is set. That agrees with detection, but it would also have silently stripped an explicit `--color=truecolor`, leaving us claiming a depth the frames never reached the terminal in. A named depth outranks the environment, so an explicit `--color` calls `force_color_output` to say which answer won.

## Testing

19 new tests (`color` 16, `cli` 3), 124 passing overall. `cargo fmt --check`, `cargo clippy -D warnings` and `cargo +1.88 check` clean.

Verified against the real binary by counting the escape sequences it emits:

| invocation | `38;2` (24-bit) | `38;5` (indexed) | `[7m` (reverse) | half-blocks |
|---|---|---|---|---|
| default, kitty | yes | – | yes | 1272 |
| `--color=256` | – | yes | yes | 1272 |
| `--color=never` | – | – | yes | 0 |
| `TERM=xterm-256color COLORTERM=` | – | yes | yes | 1272 |
| `TERM=dumb` | – | – | yes | 0 |
| `NO_COLOR=1` | – | – | yes | 0 |
| `NO_COLOR=1 --color=truecolor` | yes | – | yes | 1272 |
| `NO_COLOR=1 --color=256` | – | yes | yes | 1272 |

In `never` mode the full info panel and evolution chain still render as text (Pikachu, Electric, Mouse Pokémon, the stat rows, Pichu → Pikachu → Raichu); only the artwork is gone. The indices the 256 path emits are the expected spread for Pikachu — yellows 214–223, browns 130–137, outline 16/52/58, and greyscale-ramp entries 233–240.