### PR TITLE
Stop paying for frames nobody asked for

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,9 +331,17 @@ through to disk.
 
 Background fetch tasks are *producers* that send `Message`s over an `mpsc`
 channel; the main loop is the single *consumer*, draining that channel alongside
-terminal input and a steady animation tick via `tokio::select!`. The UI thread
-never blocks on I/O, and no state is shared across tasks — a task owns what it
-needs and hands the result back as a message.
+terminal input and an animation tick via `tokio::select!`. The UI thread never
+blocks on I/O, and no state is shared across tasks — a task owns what it needs
+and hands the result back as a message.
+
+The tick is not steady: it is selected on only while something is in flight,
+which is the only time a spinner is on screen to animate. Idle, the loop blocks
+on input and messages alone and draws when one of them says something changed,
+so a Pokédex left open in a split costs nothing at all — an idle measurement
+goes from ~1.1% of a core to 0.00%. Waking up uses `MissedTickBehavior::Delay`,
+so a ticker whose deadline went by during a long sleep fires once and schedules
+the next a full period out, rather than bursting through every frame it missed.
 
 ### Caching
 
@@ -401,6 +409,7 @@ half-block cells, foreground being the top pixel and background the bottom.
 
 Area averaging rather than nearest-neighbour sampling is what keeps downscaled
 sprites smooth instead of leaving the hard outline pixels as ragged lines.
+
 Sprites are cached re-encoded as PNG rather than as raw RGBA: a few kilobytes
 compressed against ~36 KB flattened, and the decoder is already a dependency.
 

--- a/README.md
+++ b/README.md
@@ -410,6 +410,12 @@ half-block cells, foreground being the top pixel and background the bottom.
 Area averaging rather than nearest-neighbour sampling is what keeps downscaled
 sprites smooth instead of leaving the hard outline pixels as ragged lines.
 
+The crop box is a property of the pixels, so it is worked out once when the
+sprite is decoded rather than on every draw. It used to be a full 96×96 scan per
+sprite per frame, and a frame showing an evolution chain draws ten of them —
+measured at 16.8 µs against the 16.9 µs the downsample itself costs, so caching
+it halves the sprite work in a frame. `Sprite`'s fields are private for the same
+reason: a crop box stored beside the pixels must not be able to outlive them.
 Sprites are cached re-encoded as PNG rather than as raw RGBA: a few kilobytes
 compressed against ~36 KB flattened, and the decoder is already a dependency.
 

--- a/src/api.rs
+++ b/src/api.rs
@@ -326,11 +326,7 @@ pub async fn fetch_sprite(client: &reqwest::Client, url: &str) -> Result<Sprite,
     let image = image::load_from_memory(&bytes)?.to_rgba8();
     let (width, height) = image.dimensions();
     let pixels = image.pixels().map(|p| p.0).collect();
-    Ok(Sprite {
-        width,
-        height,
-        pixels,
-    })
+    Ok(Sprite::new(width, height, pixels))
 }
 
 async fn fetch_detail(client: &reqwest::Client, name: &str) -> Result<PokemonDetail, ApiError> {

--- a/src/app.rs
+++ b/src/app.rs
@@ -13,6 +13,7 @@ use futures::StreamExt;
 use ratatui::widgets::ListState;
 use ratatui::DefaultTerminal;
 use tokio::sync::mpsc;
+use tokio::time::MissedTickBehavior;
 
 use crate::api;
 use crate::api::ApiError;
@@ -26,6 +27,9 @@ use crate::models::{
 use crate::query::Query;
 use crate::session::{self, Session};
 use crate::team;
+
+/// How often the loading spinner advances, while there is one to advance.
+const SPINNER_TICK: Duration = Duration::from_millis(120);
 
 /// Messages sent from background fetch tasks to the UI loop. The payloads are
 /// large but short-lived and low-frequency, so the size difference between
@@ -272,7 +276,15 @@ impl App {
         self.fetch_list();
 
         let mut events = EventStream::new();
-        let mut ticker = tokio::time::interval(Duration::from_millis(120));
+        let mut ticker = tokio::time::interval(SPINNER_TICK);
+        // Nothing polls the ticker while the app is idle, so by the time it is
+        // wanted again its deadline is far in the past. `Burst` — the default —
+        // would answer that by firing every tick it missed back to back,
+        // spinning the wheel through a whole sleep's worth of frames the moment
+        // a request starts. `Delay` fires once and schedules the next a full
+        // period out, which is what makes waking up look like starting rather
+        // than catching up.
+        ticker.set_missed_tick_behavior(MissedTickBehavior::Delay);
 
         while !self.should_quit {
             // Cheap, idempotent: requests a translation only when the current
@@ -290,6 +302,14 @@ impl App {
                 color::degrade(frame.buffer_mut(), depth);
             })?;
 
+            // The ticker exists to animate the spinner, and the spinner is
+            // only on screen while something is in flight. Selecting on it
+            // unconditionally is what made an idle Pokedex — the kind of thing
+            // left open in a split for hours — redraw itself eight times a
+            // second forever. Idle, the loop now blocks on input and messages
+            // alone, and draws when one of them says something changed.
+            let animating = self.is_busy();
+
             tokio::select! {
                 maybe_msg = rx.recv() => {
                     if let Some(msg) = maybe_msg {
@@ -303,7 +323,7 @@ impl App {
                         None => self.should_quit = true,
                     }
                 }
-                _ = ticker.tick() => {
+                _ = ticker.tick(), if animating => {
                     self.spinner = self.spinner.wrapping_add(1);
                 }
             }
@@ -311,6 +331,26 @@ impl App {
 
         session::store(&self.snapshot()).await;
         Ok(())
+    }
+
+    /// Whether anything is in flight — which is exactly when a spinner is on
+    /// screen, and so exactly when there is any reason to redraw on a timer.
+    ///
+    /// Every field here is the pending set of one kind of request, so "is
+    /// anything loading" is the union of them being non-empty. `team_loading`
+    /// counts too: a party member's record is fetched without the detail panel
+    /// waiting on it, but the party card draws a spinner for it just the same.
+    pub fn is_busy(&self) -> bool {
+        self.list_loading
+            || self.loading_detail.is_some()
+            || !self.type_loading.is_empty()
+            || !self.ability_loading.is_empty()
+            || !self.translating.is_empty()
+            || !self.team_loading.is_empty()
+            || self
+                .sprite_loading
+                .values()
+                .any(|pending| !pending.is_empty())
     }
 
     // --- Session persistence ---------------------------------------------
@@ -1310,6 +1350,65 @@ mod tests {
             })
             .collect();
         app
+    }
+
+    #[test]
+    fn an_app_with_nothing_in_flight_is_idle() {
+        assert!(!app_listing(&[]).is_busy());
+    }
+
+    #[test]
+    fn any_one_pending_request_is_enough_to_keep_the_spinner_turning() {
+        // One arm per kind of request. All of them put a spinner on screen, so
+        // all of them have to keep the ticker alive; a kind missing from
+        // `is_busy` would show as a frozen spinner, which is the failure this
+        // pins down.
+        /// What kind of request to start, and how to start it.
+        type Pending = (&'static str, fn(&mut App));
+
+        let cases: [Pending; 7] = [
+            ("list", |app| app.list_loading = true),
+            ("detail", |app| app.loading_detail = Some("mew".to_string())),
+            ("type roster", |app| {
+                app.type_loading.insert("ghost".to_string());
+            }),
+            ("ability", |app| {
+                app.ability_loading.insert("levitate".to_string());
+            }),
+            ("translation", |app| {
+                app.translating
+                    .insert(("mew".to_string(), "tr".to_string()));
+            }),
+            ("party member", |app| {
+                app.team_loading.insert("mew".to_string());
+            }),
+            ("sprite", |app| {
+                app.sprite_loading
+                    .entry(SpriteVariant::Normal)
+                    .or_default()
+                    .insert("mew".to_string());
+            }),
+        ];
+
+        for (kind, begin) in cases {
+            let mut app = app_listing(&[]);
+            begin(&mut app);
+            assert!(
+                app.is_busy(),
+                "a pending {kind} request should read as busy"
+            );
+        }
+    }
+
+    #[test]
+    fn a_pending_set_that_has_drained_stops_counting() {
+        // `sprite_loading` keeps one set per palette and the sets outlive their
+        // contents. Testing the map for emptiness rather than its sets would
+        // leave the app busy — and redrawing on a timer — forever after the
+        // first sprite it ever fetched.
+        let mut app = app_listing(&[]);
+        app.sprite_loading.entry(SpriteVariant::Normal).or_default();
+        assert!(!app.is_busy());
     }
 
     #[test]

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -144,11 +144,11 @@ pub async fn load_sprite(name: &str, variant: SpriteVariant) -> Option<Sprite> {
     let bytes = tokio::fs::read(&path).await.ok()?;
     let image = image::load_from_memory(&bytes).ok()?.to_rgba8();
     let (width, height) = image.dimensions();
-    Some(Sprite {
+    Some(Sprite::new(
         width,
         height,
-        pixels: image.pixels().map(|p| p.0).collect(),
-    })
+        image.pixels().map(|p| p.0).collect(),
+    ))
 }
 
 pub async fn store_sprite(name: &str, sprite: &Sprite, variant: SpriteVariant) {
@@ -390,8 +390,8 @@ async fn age(path: &Path) -> Option<Duration> {
 }
 
 fn encode_png(sprite: &Sprite) -> Option<Vec<u8>> {
-    let flat: Vec<u8> = sprite.pixels.iter().flatten().copied().collect();
-    let buffer = image::RgbaImage::from_raw(sprite.width, sprite.height, flat)?;
+    let flat: Vec<u8> = sprite.pixels().iter().flatten().copied().collect();
+    let buffer = image::RgbaImage::from_raw(sprite.width(), sprite.height(), flat)?;
     let mut out = Vec::new();
     image::DynamicImage::ImageRgba8(buffer)
         .write_to(&mut std::io::Cursor::new(&mut out), image::ImageFormat::Png)
@@ -516,17 +516,13 @@ mod tests {
 
     #[test]
     fn sprites_survive_a_png_round_trip() {
-        let sprite = Sprite {
-            width: 2,
-            height: 1,
-            pixels: vec![[255, 0, 0, 255], [0, 128, 255, 128]],
-        };
+        let sprite = Sprite::new(2, 1, vec![[255, 0, 0, 255], [0, 128, 255, 128]]);
         let bytes = encode_png(&sprite).unwrap();
         let decoded = image::load_from_memory(&bytes).unwrap().to_rgba8();
         assert_eq!(decoded.dimensions(), (2, 1));
         assert_eq!(
             decoded.pixels().map(|p| p.0).collect::<Vec<_>>(),
-            sprite.pixels
+            sprite.pixels()
         );
     }
 }

--- a/src/models.rs
+++ b/src/models.rs
@@ -359,15 +359,50 @@ impl EvolutionTree {
 ///
 /// Sprites are tiny (PokeAPI's `front_default` is 96×96), so we keep the full
 /// image in memory and downsample at draw time to whatever space is available.
+/// The fields are private because [`bounds`](Self::content_bounds) is derived
+/// from the pixels: letting anything rewrite them after the fact would leave a
+/// crop box describing an image that no longer exists.
 #[derive(Debug, Clone)]
 pub struct Sprite {
-    pub width: u32,
-    pub height: u32,
+    width: u32,
+    height: u32,
     /// Row-major RGBA, four bytes per pixel.
-    pub pixels: Vec<[u8; 4]>,
+    pixels: Vec<[u8; 4]>,
+    /// Tight bounding box of the opaque pixels, computed once here rather than
+    /// on every frame. See [`content_bounds`](Self::content_bounds).
+    bounds: (u32, u32, u32, u32),
 }
 
 impl Sprite {
+    /// Decodes into a sprite, working out the crop box as it goes.
+    ///
+    /// The box is a property of the pixels and nothing else, so computing it
+    /// here costs one pass over an image we have just finished decoding
+    /// anyway — against a full 96x96 scan per sprite per frame, which is what
+    /// it replaces.
+    pub fn new(width: u32, height: u32, pixels: Vec<[u8; 4]>) -> Self {
+        let bounds = compute_content_bounds(width, height, &pixels);
+        Sprite {
+            width,
+            height,
+            pixels,
+            bounds,
+        }
+    }
+
+    pub fn width(&self) -> u32 {
+        self.width
+    }
+
+    pub fn height(&self) -> u32 {
+        self.height
+    }
+
+    /// Row-major RGBA, for re-encoding the image on its way to the cache.
+    pub fn pixels(&self) -> &[[u8; 4]] {
+        &self.pixels
+    }
+
     /// Average RGBA over the source box `[x0..=x1] × [y0..=y1]`, weighting color
     /// by alpha so transparent pixels don't muddy the result. The returned alpha
     /// is the box's mean coverage. Averaging (rather than nearest-neighbour point
@@ -396,32 +431,40 @@ impl Sprite {
 
     /// Tight bounding box `(x0, y0, x1, y1)` (inclusive) of the non-transparent
     /// pixels. PokeAPI artwork sits in a large transparent margin; cropping to
-    /// this box lets the visible Pokemon fill its on-screen cell. Falls back to
-    /// the full image if nothing is opaque.
+    /// this box lets the visible Pokemon fill its on-screen cell.
+    ///
+    /// Read straight off the struct. It used to be a full scan of the image,
+    /// run afresh every time the sprite was drawn — which meant once per frame
+    /// per sprite, and a frame showing an evolution chain draws ten of them.
+    /// Nothing about the answer depends on anything that changes between
+    /// frames, so it is worked out once in [`Sprite::new`] instead.
     pub fn content_bounds(&self) -> (u32, u32, u32, u32) {
-        let (mut x0, mut y0, mut x1, mut y1) = (self.width, self.height, 0u32, 0u32);
-        let mut found = false;
-        for y in 0..self.height {
-            for x in 0..self.width {
-                if self.pixels[(y * self.width + x) as usize][3] >= 128 {
-                    found = true;
-                    x0 = x0.min(x);
-                    y0 = y0.min(y);
-                    x1 = x1.max(x);
-                    y1 = y1.max(y);
-                }
+        self.bounds
+    }
+}
+
+/// The scan behind [`Sprite::content_bounds`], as a free function so it can run
+/// before there is a `Sprite` to call it on. Falls back to the whole image when
+/// nothing is opaque, which keeps a fully transparent sprite renderable rather
+/// than making it a special case downstream.
+fn compute_content_bounds(width: u32, height: u32, pixels: &[[u8; 4]]) -> (u32, u32, u32, u32) {
+    let (mut x0, mut y0, mut x1, mut y1) = (width, height, 0u32, 0u32);
+    let mut found = false;
+    for y in 0..height {
+        for x in 0..width {
+            if pixels[(y * width + x) as usize][3] >= 128 {
+                found = true;
+                x0 = x0.min(x);
+                y0 = y0.min(y);
+                x1 = x1.max(x);
+                y1 = y1.max(y);
             }
         }
-        if found {
-            (x0, y0, x1, y1)
-        } else {
-            (
-                0,
-                0,
-                self.width.saturating_sub(1),
-                self.height.saturating_sub(1),
-            )
-        }
+    }
+    if found {
+        (x0, y0, x1, y1)
+    } else {
+        (0, 0, width.saturating_sub(1), height.saturating_sub(1))
     }
 }
 
@@ -443,6 +486,54 @@ pub fn title_case(raw: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// A sprite with one opaque rectangle inside a transparent margin, which is
+    /// the shape every PokeAPI sprite has.
+    fn framed_sprite(width: u32, height: u32, box_: (u32, u32, u32, u32)) -> Sprite {
+        let (x0, y0, x1, y1) = box_;
+        let pixels = (0..width * height)
+            .map(|i| {
+                let (x, y) = (i % width, i / width);
+                let opaque = (x0..=x1).contains(&x) && (y0..=y1).contains(&y);
+                [10, 20, 30, if opaque { 255 } else { 0 }]
+            })
+            .collect();
+        Sprite::new(width, height, pixels)
+    }
+
+    #[test]
+    fn the_stored_crop_box_is_the_one_a_scan_would_have_found() {
+        for box_ in [(18, 13, 77, 82), (0, 0, 95, 95), (40, 40, 41, 41)] {
+            let sprite = framed_sprite(96, 96, box_);
+            assert_eq!(sprite.content_bounds(), box_);
+            assert_eq!(
+                sprite.content_bounds(),
+                compute_content_bounds(sprite.width(), sprite.height(), sprite.pixels()),
+                "the box on the struct must not drift from the pixels it describes"
+            );
+        }
+    }
+
+    #[test]
+    fn a_sprite_with_nothing_opaque_falls_back_to_the_whole_image() {
+        let sprite = Sprite::new(4, 3, vec![[0, 0, 0, 0]; 12]);
+        assert_eq!(sprite.content_bounds(), (0, 0, 3, 2));
+        assert_eq!(
+            sprite.content_bounds(),
+            compute_content_bounds(4, 3, sprite.pixels())
+        );
+    }
+
+    #[test]
+    fn half_transparent_pixels_do_not_count_towards_the_crop() {
+        // The scan's threshold is alpha >= 128, so a faint edge does not drag
+        // the box back out to the margin it was cropped away from.
+        let mut pixels = vec![[0u8, 0, 0, 0]; 16];
+        pixels[5] = [10, 20, 30, 255];
+        pixels[0] = [10, 20, 30, 127];
+        let sprite = Sprite::new(4, 4, pixels);
+        assert_eq!(sprite.content_bounds(), (1, 1, 1, 1));
+    }
 
     fn entry(id: u32) -> PokemonEntry {
         PokemonEntry {

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -443,7 +443,7 @@ fn render_sprite(frame: &mut Frame, area: Rect, sprite: &Sprite) {
 /// and `max_cols` *while preserving aspect ratio* — accounting for terminal
 /// cells being roughly twice as tall as they are wide — and finally centred.
 fn render_sprite_capped(frame: &mut Frame, area: Rect, sprite: &Sprite, max_cols: u16) {
-    if area.width < 2 || area.height < 1 || sprite.width == 0 || sprite.height == 0 {
+    if area.width < 2 || area.height < 1 || sprite.width() == 0 || sprite.height() == 0 {
         return;
     }
 


### PR DESCRIPTION
Closes #15. Closes #16.

Two halves of the same problem: #15 is *why are we drawing this often*, #16 is *why is each drawing this expensive*. Two commits, separately reviewable.

## Idle redraws (#15)

The loop drove a 120 ms ticker unconditionally, and every tick redrew the whole interface — roughly eight full renders a second, forever, including on a completely idle screen. The spinner is the only thing the tick exists for, and the app already knows when one is up: `is_busy` is the union of the pending sets (`list_loading`, `loading_detail`, sprites, type rosters, abilities, translations, party members). The ticker is now a conditional `select!` branch.

Waking up needed care. Nothing polls the ticker while idle, so its deadline is far in the past by the time it is wanted again, and `Burst` — the default — would answer that by firing every missed tick back to back, spinning the wheel through a whole sleep's worth of frames at once. `MissedTickBehavior::Delay` fires once and schedules the next a full period out.

**Idle CPU**, release build at 140×40, settled screen, `utime+stime` over a ten-second window:

| | run 1 | run 2 | run 3 |
|---|---|---|---|
| before | 1.10% | 1.10% | 1.20% |
| after | 0.00% | 0.00% | 0.00% |

A cold start still draws the spinner through its full ten-frame cycle (`⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏`), verified against the emitted glyphs before and after.

## The crop box (#16)

`render_sprite_capped` opened by scanning all 96×96 pixels for the opaque bounding box, every frame, per sprite — and a frame showing a full evolution chain draws ten of them. The box is a property of the pixels, so it is computed once in `Sprite::new` and read off the struct thereafter; both construction sites (a download in `api`, a cached PNG in `cache`) go through it.

Measured on the shape a PokeAPI sprite actually has — a 60×70 opaque blob in a 96×96 frame:

| | per sprite |
|---|---|
| `content_bounds` scan | 16.8 µs |
| `box_average` downsample | 16.9 µs |

So a ten-sprite frame goes from ~337 µs of sprite work to ~169 µs. `Sprite`'s fields are private now, with accessors for the three readers outside the module: a crop box stored beside the pixels it describes must not be able to outlive them, and that is cheaper to enforce than to remember.

## What is deliberately not here

The issue's second step — memoizing rendered cells per `(name, variant, cell size)` — is **not** done, and the numbers above are why. Its case rested on being paired with the unconditional idle redraw ("*Paired with #15 that runs continuously on an idle screen*"), which no longer exists: frames now happen only when input or a message says something changed, and 169 µs on those is not worth a cache to invalidate on resize. #16 already allows for this — "*the first step is worth doing on its own even if the second is judged not worth the memory*" — but say the word and I will add it.

Worth noting what the idle measurement implies: sprite resampling was ~0.27% of the 1.1%, so the bulk of the idle cost was the general redraw, not the sprites. #15 is what removed it.

## Testing

6 new tests, 130 passing overall. `cargo fmt --check`, `cargo clippy -D warnings`, `cargo +1.88 check` clean.

- `is_busy` gets one arm per kind of request — a kind missing from it would show as a frozen spinner — plus the case that matters for `sprite_loading`, whose per-palette sets outlive their contents: testing the map for emptiness rather than its sets would leave the app redrawing on a timer forever after the first sprite it ever fetched.
- The crop box is pinned against a freshly computed one for the same pixels, including the all-transparent fallback and the alpha ≥ 128 threshold.

End to end on the release build: sprites still render (1400 half-blocks, truecolor), the Gengar line still resolves Gastly → Haunter → Gengar.