### PR TITLE
Automate releases, and record what changed in them

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,182 @@
+name: Release
+
+# Driven by the tag, which is the one deliberate "this is a release" gesture.
+# Everything after it — verifying, cross-compiling, the GitHub release, and
+# crates.io — happens here, so the crate and the binaries can never drift apart
+# in version.
+on:
+  push:
+    tags: ["v*"]
+  # Lets the build matrix be exercised without cutting a release. Only the two
+  # publishing jobs are gated on a tag, so a manual run answers "does this still
+  # cross-compile" — the question you want settled *before* tagging, since a tag
+  # that fails halfway leaves a release half-made.
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  # Nothing irreversible happens before this passes. CI already runs on every
+  # push, but a tag can point at any commit, so the check is repeated against
+  # the exact tree about to be published rather than assumed from a green run
+  # somewhere upstream.
+  verify:
+    name: Verify
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+      - uses: Swatinem/rust-cache@v2
+
+      # A tag naming a version the manifest does not agree with would publish a
+      # crate under one number and binaries under another. Cheaper to catch here
+      # than to yank afterwards.
+      - name: Tag matches the manifest version
+        if: startsWith(github.ref, 'refs/tags/')
+        run: |
+          tagged="${GITHUB_REF_NAME#v}"
+          manifest=$(cargo metadata --format-version 1 --no-deps | jq -r '.packages[0].version')
+          echo "tag $tagged, manifest $manifest"
+          [ "$tagged" = "$manifest" ] || {
+            echo "::error::tag $GITHUB_REF_NAME does not match Cargo.toml version $manifest"
+            exit 1
+          }
+
+      - name: The changelog has an entry for this version
+        if: startsWith(github.ref, 'refs/tags/')
+        run: |
+          grep -q "^## \[${GITHUB_REF_NAME#v}\]" CHANGELOG.md || {
+            echo "::error::CHANGELOG.md has no section for ${GITHUB_REF_NAME#v}"
+            exit 1
+          }
+
+      - run: cargo fmt --all --check
+      - run: cargo clippy --all-targets --all-features -- -D warnings
+      - run: cargo test --all-features
+
+  build:
+    name: ${{ matrix.target }}
+    needs: verify
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # The gnu build carries the runner's glibc floor with it, so the musl
+          # one is the Linux binary that actually runs anywhere. Both ship:
+          # `rustls-tls` means neither needs a system OpenSSL.
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-latest
+          - target: x86_64-unknown-linux-musl
+            os: ubuntu-latest
+          - target: aarch64-apple-darwin
+            os: macos-latest
+          - target: x86_64-apple-darwin
+            os: macos-latest
+          - target: x86_64-pc-windows-msvc
+            os: windows-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: ${{ matrix.target }}
+
+      - name: Install the musl toolchain
+        if: endsWith(matrix.target, '-musl')
+        run: sudo apt-get update && sudo apt-get install -y musl-tools
+
+      - run: cargo build --release --locked --target ${{ matrix.target }}
+
+      # tar on Unix, zip on Windows — each platform's `curl | extract` habit.
+      # The checksum sits beside the archive rather than in one combined file so
+      # a single download can be verified without fetching anything else.
+      - name: Package
+        shell: bash
+        run: |
+          name="pokeductor-${GITHUB_REF_NAME}-${{ matrix.target }}"
+          mkdir -p "dist/$name"
+          if [ "${{ runner.os }}" = "Windows" ]; then
+            cp "target/${{ matrix.target }}/release/pokeductor.exe" "dist/$name/"
+          else
+            cp "target/${{ matrix.target }}/release/pokeductor" "dist/$name/"
+          fi
+          cp README.md LICENSE CHANGELOG.md "dist/$name/"
+          cd dist
+          if [ "${{ runner.os }}" = "Windows" ]; then
+            7z a "$name.zip" "$name" > /dev/null
+            archive="$name.zip"
+          else
+            tar czf "$name.tar.gz" "$name"
+            archive="$name.tar.gz"
+          fi
+          if command -v sha256sum > /dev/null; then
+            sha256sum "$archive" > "$archive.sha256"
+          else
+            shasum -a 256 "$archive" > "$archive.sha256"
+          fi
+          cat "$archive.sha256"
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.target }}
+          path: |
+            dist/*.tar.gz
+            dist/*.zip
+            dist/*.sha256
+          if-no-files-found: error
+
+  release:
+    name: GitHub release
+    needs: build
+    if: startsWith(github.ref, 'refs/tags/')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/download-artifact@v5
+        with:
+          path: dist
+          merge-multiple: true
+
+      # The notes are the changelog's section for this version, so the two are
+      # written once rather than kept in step by hand.
+      - name: Take the release notes from the changelog
+        run: |
+          awk -v version="${GITHUB_REF_NAME#v}" '
+            $0 ~ "^## \\[" version "\\]" { collecting = 1; next }
+            collecting && /^## / { exit }
+            collecting { print }
+          ' CHANGELOG.md > notes.md
+          [ -s notes.md ] || {
+            echo "::error::no changelog section for ${GITHUB_REF_NAME#v}"
+            exit 1
+          }
+          cat notes.md
+
+      - name: Publish the release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release create "$GITHUB_REF_NAME" dist/* --title "$GITHUB_REF_NAME" --notes-file notes.md
+
+  # Last, and only once the binaries exist: a crates.io publish cannot be undone,
+  # only yanked.
+  crates-io:
+    name: crates.io
+    needs: release
+    if: startsWith(github.ref, 'refs/tags/')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo publish --locked
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,112 @@
+# Changelog
+
+All notable changes to this project are documented here. The format follows
+[Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and versions follow
+[Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+`0.1.0` and `0.2.0` predate this file and are reconstructed from the commit
+history, so they are summaries rather than the record kept as the work landed.
+Tagging began at `0.3.0`, so those two link commit ranges rather than tags.
+
+## [Unreleased]
+
+### Added
+
+- A command-line interface: `pokeductor <name>` opens straight on a species,
+  `--lang` picks the interface language, `--clear-cache` and `--cache-dir`
+  manage the on-disk cache, and `--version` and `--help` answer at last. The
+  name argument goes through the search box, so `pokeductor 25` and
+  `pokeductor type:ghost` work too. (#5)
+- Terminal colour-depth detection. Sprites quantize to the xterm-256 palette on
+  terminals without truecolor instead of being dropped, and `--color` and
+  `NO_COLOR` override what detection concluded. (#4)
+- The party, interface language, sort order and shiny toggle are carried over
+  between runs, kept under `$XDG_STATE_HOME/pokeductor`.
+
+### Changed
+
+- `reqwest` now uses `rustls-tls` rather than the platform's TLS. Release
+  binaries link no system OpenSSL and carry their own root certificates, which
+  is what lets one Linux build run anywhere.
+- With no colour available, sprites are skipped in favour of the placeholder the
+  panels already fall back to, and the list cursor falls back to reverse video.
+
+### Fixed
+
+- The type matchup card ignored the ability immunities the party card already
+  accounted for, so the two disagreed about the same species. (#13)
+
+### Performance
+
+- An idle screen no longer redraws eight times a second. The animation tick runs
+  only while a request is in flight, which is the only time a spinner is on
+  screen: measured idle CPU goes from ~1.1% of a core to 0.00%. (#15)
+- A sprite's crop box is worked out once when it is decoded rather than scanned
+  out of all 96×96 pixels on every frame, halving the sprite work in a frame
+  that draws a full evolution chain. (#16)
+
+## [0.3.1] - 2026-08-21
+
+### Fixed
+
+- Updated `h2` past the empty-DATA-frame advisory.
+- Dex range assertions no longer depend on their ranges being single-element.
+
+## [0.3.0] - 2026-08-21
+
+### Added
+
+- An app-wide shiny artwork toggle behind `X`, fetching and caching only the
+  palette on screen. (#10)
+- Dex-number search: a bare number finds that Pokédex entry, and `dex:` takes a
+  number or a range. (#18)
+- CI covering formatting, lint, tests on three platforms, and the MSRV. (#1)
+- The AUR package documented in the install section.
+
+### Fixed
+
+- Evolution cards stayed blank for species whose default form is named
+  differently; the default variety is now resolved before artwork is
+  requested. (#12)
+- A species recorded as having no artwork was written off permanently. That
+  answer now expires, since sprites get backfilled for newly added
+  species. (#14)
+
+### Changed
+
+- The API client gained timeouts, bounded retries and a concurrency cap, so a
+  slow or flaky network degrades instead of hanging. (#2)
+- Updated `anyhow` past the `downcast_mut` unsoundness advisory.
+
+## [0.2.0] - 2026-08-12
+
+### Added
+
+- Offline type-effectiveness analysis: a built-in Generation VI+ chart, and a
+  matchup card that opens instantly with no request.
+- A party builder with team-wide type analysis — shared weaknesses, unresisted
+  types, ability immunities and offensive gaps.
+- An abilities card, with descriptions fetched on demand and cached.
+- Search filters (`type:`, `gen:`) and a sortable sidebar.
+- Evolution requirements spelled out per stage, sized to the panel.
+- An on-disk cache of every fetched response, for instant and offline starts.
+- A help overlay behind `?`.
+
+### Changed
+
+- The app opens on the first species instead of an empty panel.
+- The README rewritten around the interface as it actually is.
+
+## [0.1.0] - 2026-06-16
+
+### Added
+
+- The first release: a terminal Pokédex over PokeAPI, with sprite rendering as
+  Unicode half-blocks, evolution chains as connected cards, a language menu, and
+  the retro colour palette.
+
+[Unreleased]: https://github.com/Huseynteymurzade28/pokeductor/compare/v0.3.1...HEAD
+[0.3.1]: https://github.com/Huseynteymurzade28/pokeductor/compare/v0.3.0...v0.3.1
+[0.3.0]: https://github.com/Huseynteymurzade28/pokeductor/compare/77c1e8d...v0.3.0
+[0.2.0]: https://github.com/Huseynteymurzade28/pokeductor/compare/94eadb8...77c1e8d
+[0.1.0]: https://github.com/Huseynteymurzade28/pokeductor/compare/a42a22b...94eadb8

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -150,6 +150,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
+
+[[package]]
+name = "chacha20"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "rand_core",
+]
+
+[[package]]
 name = "clap"
 version = "4.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -210,30 +227,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "core-foundation"
-version = "0.9.4"
+name = "cpufeatures"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
- "core-foundation-sys",
  "libc",
 ]
-
-[[package]]
-name = "core-foundation"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
-name = "core-foundation-sys"
-version = "0.8.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "crc32fast"
@@ -255,7 +255,7 @@ dependencies = [
  "futures-core",
  "mio",
  "parking_lot",
- "rustix 0.38.44",
+ "rustix",
  "signal-hook",
  "signal-hook-mio",
  "winapi",
@@ -322,15 +322,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
-name = "encoding_rs"
-version = "0.8.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -345,12 +336,6 @@ dependencies = [
  "libc",
  "windows-sys 0.61.2",
 ]
-
-[[package]]
-name = "fastrand"
-version = "2.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "fdeflate"
@@ -378,31 +363,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "fnv"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
-
-[[package]]
 name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
-
-[[package]]
-name = "foreign-types"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-dependencies = [
- "foreign-types-shared",
-]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
@@ -508,8 +472,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -519,29 +485,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi",
+ "rand_core",
  "wasip2",
  "wasip3",
-]
-
-[[package]]
-name = "h2"
-version = "0.4.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "839c0e8a181239723652be9062bb56ca5bf5f64011f73b623f6f4fc59086a228"
-dependencies = [
- "atomic-waker",
- "bytes",
- "fnv",
- "futures-core",
- "futures-sink",
- "http",
- "indexmap",
- "slab",
- "tokio",
- "tokio-util",
- "tracing",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -616,7 +566,6 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
- "h2",
  "http",
  "http-body",
  "httparse",
@@ -640,22 +589,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
-]
-
-[[package]]
-name = "hyper-tls"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
-dependencies = [
- "bytes",
- "http-body-util",
- "hyper",
- "hyper-util",
- "native-tls",
- "tokio",
- "tokio-native-tls",
- "tower-service",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -676,11 +610,9 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "socket2",
- "system-configuration",
  "tokio",
  "tower-service",
  "tracing",
- "windows-registry",
 ]
 
 [[package]]
@@ -902,12 +834,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
-name = "linux-raw-sys"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
-
-[[package]]
 name = "litemap"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -938,16 +864,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
 name = "memchr"
 version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
-
-[[package]]
-name = "mime"
-version = "0.3.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "miniz_oxide"
@@ -982,23 +908,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "native-tls"
-version = "0.2.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
-dependencies = [
- "libc",
- "log",
- "openssl",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "security-framework",
- "security-framework-sys",
- "tempfile",
-]
-
-[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1018,49 +927,6 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
-
-[[package]]
-name = "openssl"
-version = "0.10.81"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77823a27f0babb03091cb9ed9ef80af3b39dbc82f97e8fa530374b7dafd87a45"
-dependencies = [
- "bitflags",
- "cfg-if",
- "foreign-types",
- "libc",
- "openssl-macros",
- "openssl-sys",
-]
-
-[[package]]
-name = "openssl-macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "openssl-probe"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.117"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b47e7e6bb2c38cd930d25a23b40fa52e068c10e85f3e03a7f5ba5aaca5713695"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
 
 [[package]]
 name = "parking_lot"
@@ -1102,12 +968,6 @@ name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
-
-[[package]]
-name = "pkg-config"
-version = "0.3.33"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "png"
@@ -1174,6 +1034,62 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0c5ccf5294c6ccd63a74f1565028353830a9c2f5eb0c682c355c471726a6e3f"
 
 [[package]]
+name = "quinn"
+version = "0.11.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
+dependencies = [
+ "bytes",
+ "getrandom 0.4.2",
+ "lru-slab",
+ "rand",
+ "rand_pcg",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35a133f956daabe89a61a685c2649f13d82d5aa4bd5d12d1277e1072a21c0694"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1187,6 +1103,32 @@ name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.2",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
+dependencies = [
+ "rand_core",
+]
 
 [[package]]
 name = "ratatui"
@@ -1226,29 +1168,26 @@ checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
  "base64",
  "bytes",
- "encoding_rs",
  "futures-core",
- "h2",
  "http",
  "http-body",
  "http-body-util",
  "hyper",
  "hyper-rustls",
- "hyper-tls",
  "hyper-util",
  "js-sys",
  "log",
- "mime",
- "native-tls",
  "percent-encoding",
  "pin-project-lite",
+ "quinn",
+ "rustls",
  "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
- "tokio-native-tls",
+ "tokio-rustls",
  "tower",
  "tower-http",
  "tower-service",
@@ -1256,6 +1195,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -1273,6 +1213,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc-hash"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
+
+[[package]]
 name = "rustix"
 version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1281,21 +1227,8 @@ dependencies = [
  "bitflags",
  "errno",
  "libc",
- "linux-raw-sys 0.4.15",
+ "linux-raw-sys",
  "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "rustix"
-version = "1.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
-dependencies = [
- "bitflags",
- "errno",
- "libc",
- "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1305,6 +1238,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
  "once_cell",
+ "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
@@ -1317,6 +1251,7 @@ version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
 dependencies = [
+ "web-time",
  "zeroize",
 ]
 
@@ -1344,42 +1279,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
-name = "schannel"
-version = "0.1.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
-dependencies = [
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
-name = "security-framework"
-version = "3.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
-dependencies = [
- "bitflags",
- "core-foundation 0.10.1",
- "core-foundation-sys",
- "libc",
- "security-framework-sys",
-]
-
-[[package]]
-name = "security-framework-sys"
-version = "2.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
 
 [[package]]
 name = "semver"
@@ -1596,40 +1499,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "system-configuration"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
-dependencies = [
- "bitflags",
- "core-foundation 0.9.4",
- "system-configuration-sys",
-]
-
-[[package]]
-name = "system-configuration-sys"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
-name = "tempfile"
-version = "3.27.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
-dependencies = [
- "fastrand",
- "getrandom 0.4.2",
- "once_cell",
- "rustix 1.1.4",
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1660,6 +1529,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
 name = "tokio"
 version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1686,35 +1570,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-native-tls"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
-dependencies = [
- "native-tls",
- "tokio",
-]
-
-[[package]]
 name = "tokio-rustls"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
  "rustls",
- "tokio",
-]
-
-[[package]]
-name = "tokio-util"
-version = "0.7.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
-dependencies = [
- "bytes",
- "futures-core",
- "futures-sink",
- "pin-project-lite",
  "tokio",
 ]
 
@@ -1860,12 +1721,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
-name = "vcpkg"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
-
-[[package]]
 name = "want"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1998,6 +1853,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dcd9d09a39985f5344844e66b0c530a33843579125f23e21e9f0f220850f22a"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2024,35 +1898,6 @@ name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
-
-[[package]]
-name = "windows-registry"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
-dependencies = [
- "windows-link",
- "windows-result",
- "windows-strings",
-]
-
-[[package]]
-name = "windows-result"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
-dependencies = [
- "windows-link",
-]
-
-[[package]]
-name = "windows-strings"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
-dependencies = [
- "windows-link",
-]
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,11 @@ exclude = ["assets/", ".github/"]
 ratatui = "0.29"
 crossterm = { version = "0.28", features = ["event-stream"] }
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "sync", "time", "fs"] }
-reqwest = { version = "0.12", features = ["json"] }
+# `rustls-tls` rather than the default `native-tls`: it is what lets a release
+# binary be built once and run anywhere, since it links no system OpenSSL and
+# carries its own root certificates. It is also what makes the musl target
+# possible at all.
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 futures = "0.3"

--- a/README.md
+++ b/README.md
@@ -25,6 +25,30 @@ building a party, and the help overlay:
 
 ## Install
 
+### Prebuilt binaries
+
+No toolchain needed. Each [release](https://github.com/Huseynteymurzade28/pokeductor/releases)
+carries an archive per platform, with a `.sha256` beside it:
+
+| Platform | Archive |
+|---|---|
+| Linux (any distribution) | `x86_64-unknown-linux-musl.tar.gz` |
+| Linux (glibc) | `x86_64-unknown-linux-gnu.tar.gz` |
+| macOS (Apple silicon) | `aarch64-apple-darwin.tar.gz` |
+| macOS (Intel) | `x86_64-apple-darwin.tar.gz` |
+| Windows | `x86_64-pc-windows-msvc.zip` |
+
+Take the **musl** one on Linux unless you have a reason not to: it is statically
+linked and carries no glibc floor, so it runs on distributions older than the
+machine it was built on. Both Linux builds link no system OpenSSL.
+
+```bash
+tar xzf pokeductor-v0.3.1-x86_64-unknown-linux-musl.tar.gz
+./pokeductor-v0.3.1-x86_64-unknown-linux-musl/pokeductor
+```
+
+### With cargo
+
 ```bash
 cargo install pokeductor
 ```
@@ -46,8 +70,9 @@ yay -S pokeductor
 
 ### Requirements
 
-- **Rust 1.88 or newer** (2021 edition) — via [rustup](https://rustup.rs/). Not
-  needed for the AUR package, which builds it for you.
+- **Rust 1.88 or newer** (2021 edition) — via [rustup](https://rustup.rs/).
+  Only for building it yourself: the prebuilt binaries and the AUR package need
+  no toolchain.
 - A **truecolor (24-bit) terminal** for sprites at their best. Not a
   requirement: a 256-colour terminal gets the artwork quantized to its palette,
   and one with no colour at all gets the interface without sprites rather than a
@@ -552,6 +577,28 @@ manifest changes.
 Everything under `typechart.rs`, `team.rs`, `query.rs` and `models.rs` is pure
 and unit-tested; new logic belongs there rather than in `app.rs` or `ui.rs`
 wherever it can be expressed without a terminal or a network.
+
+### Releasing
+
+Changes are recorded in [`CHANGELOG.md`](CHANGELOG.md) under `Unreleased` as
+they land. A release moves that section under its version number, bumps
+`Cargo.toml`, and is tagged:
+
+```bash
+git tag -a v0.4.0 -m "v0.4.0"
+git push origin v0.4.0
+```
+
+The tag is the only manual step. Pushing it runs `.github/workflows/release.yml`,
+which re-runs the full check suite against the tagged tree, refuses to go on if
+the tag and the manifest disagree about the version or the changelog has no
+section for it, cross-compiles the five targets, attaches them with checksums to
+a GitHub release whose notes are that changelog section, and finally publishes to
+crates.io. Publishing needs a `CARGO_REGISTRY_TOKEN` repository secret.
+
+crates.io is last because it is the step that cannot be undone, only yanked. The
+AUR package is updated by hand afterwards, since it builds from the crates.io
+tarball and cannot be prepared before it exists.
 
 ## Credits
 

--- a/deny.toml
+++ b/deny.toml
@@ -23,6 +23,13 @@ allow = [
     "BSD-3-Clause",
     "BSL-1.0",
     "CC0-1.0",
+    # `webpki-roots` — the Mozilla root CA bundle that `rustls-tls` ships in
+    # place of the system trust store. The licence covers the certificate data
+    # rather than code: CDLA-Permissive-2.0 is the Linux Foundation's data
+    # licence and permits redistribution outright, with no condition beyond the
+    # usual disclaimer. Shipping it is the whole point — it is what lets a
+    # release binary verify TLS on a machine whose trust store we cannot see.
+    "CDLA-Permissive-2.0",
     "ISC",
     "MIT",
     "MIT-0",


### PR DESCRIPTION
Closes #7.

Releases were entirely manual, and `cargo install pokeductor` — needing a Rust toolchain and a from-source compile — was the only supported path. There was also no changelog.

## `CHANGELOG.md`

Keep a Changelog format, backfilled for `0.1.0` through `0.3.1` from the commit history. Tagging began at `0.3.0`, so the two older versions link commit ranges rather than tags, and the file says so — they are summaries, not the record kept as the work landed. The `Unreleased` section already holds this session's work (#5, #4, #13, #15, #16 and session persistence).

## `.github/workflows/release.yml`

Driven by a `v*` tag. Everything after the tag happens in the workflow:

1. **verify** — the full check suite re-run *against the tagged tree*. CI runs on every push, but a tag can point at any commit, so this is checked rather than assumed.
2. **build** — five targets, each archive with a `.sha256` beside it:
   `x86_64-unknown-linux-gnu`, `x86_64-unknown-linux-musl`, `aarch64-apple-darwin`, `x86_64-apple-darwin`, `x86_64-pc-windows-msvc`.
3. **release** — a GitHub release whose notes are that version's changelog section, so the notes are written once rather than twice.
4. **crates-io** — last, and only once the binaries exist. A publish cannot be undone, only yanked.

Two guards refuse to proceed rather than produce something wrong:

- a tag whose version the manifest disagrees with would publish a crate under one number and binaries under another;
- a version with no changelog section would produce a release with empty notes.

`workflow_dispatch` runs verify + build with the two publishing jobs gated off, so **"does this still cross-compile" can be answered before tagging** rather than halfway through a release that then sits half-made.

## The TLS change

`reqwest` moves from the default `native-tls` to `rustls-tls`. This is not incidental — it is what makes the binaries worth shipping:

- `openssl-sys` leaves the tree entirely, so no Linux build needs a system OpenSSL (`ldd` on the release binary shows no `libssl`);
- it is what makes the musl target possible at all, and the static musl build is the Linux binary that runs on distributions older than the machine it was built on, unlike the gnu one which carries the runner's glibc floor;
- `ring` is the crypto backend rather than `aws-lc-rs`, so `musl-tools` is all the musl job needs.

Verified against the live API on a cold cache: species fetch, evolution chain, ability text and sprite download all work over rustls (1400 half-blocks drawn, 12 files written to the cache).

## README

A **Prebuilt binaries** section ahead of `cargo install`, with a table per platform and the advice to take musl on Linux unless there's a reason not to. The Rust requirement is now qualified as "only for building it yourself". A **Releasing** section documents the process, including that `CARGO_REGISTRY_TOKEN` must exist as a repository secret.

## Before the first tagged release

- [ ] Add the **`CARGO_REGISTRY_TOKEN`** repository secret — `gh secret list` is currently empty, so the crates.io job would fail without it.
- [ ] Once merged, run the workflow manually (`gh workflow run release.yml`) to prove the five targets build, before tagging anything.

130 tests passing; `cargo fmt --check`, `cargo clippy -D warnings` and `cargo +1.88 check` clean. The workflow YAML parses and the changelog-extraction `awk` was tested against the real file, including the empty result that trips the guard.